### PR TITLE
Workaround for Facebook bug returning non-https URL for paging in batch requests

### DIFF
--- a/source/library/com/restfb/Connection.java
+++ b/source/library/com/restfb/Connection.java
@@ -157,6 +157,12 @@ public class Connection<T> implements Iterable<List<T>> {
       JsonObject jsonPaging = jsonObject.getJsonObject("paging");
       previousPageUrl = jsonPaging.has("previous") ? jsonPaging.getString("previous") : null;
       nextPageUrl = jsonPaging.has("next") ? jsonPaging.getString("next") : null;
+      if (null != previousPageUrl && previousPageUrl.startsWith("http://")) {
+        previousPageUrl = previousPageUrl.replaceFirst("http://", "https://");
+      }
+      if (null != nextPageUrl && nextPageUrl.startsWith("http://")) {
+        nextPageUrl = nextPageUrl.replaceFirst("http://", "https://");
+      }
     } else {
       previousPageUrl = null;
       nextPageUrl = null;


### PR DESCRIPTION
...36939577

There is a bug in FB occuring when using batch requests:
https://developers.facebook.com/bugs/430824836939577

Trying to iterator over the connection fails with an error 400 because the "next" URL uses http instead of https:
com.restfb.exception.FacebookOAuthException: Received Facebook error response of type OAuthException: You must use https:// when passing an access token

I patched this workaround a while back in 1.6.9 when the bug first occured and finally commited it in my fork.

Can you please merge the workaround? I'd really appreciate having a new release soon with this workaround. Thanks! 
