### PR TITLE
Handling error_subcode field in error responses

### DIFF
--- a/source/library/com/restfb/BaseFacebookClient.java
+++ b/source/library/com/restfb/BaseFacebookClient.java
@@ -133,8 +133,8 @@ abstract class BaseFacebookClient {
      *      java.lang.Integer, java.lang.String, java.lang.String)
      */
     @Override
-    public FacebookException exceptionForTypeAndMessage(Integer errorCode, Integer httpStatusCode, String type,
-        String message) {
+    public FacebookException exceptionForTypeAndMessage(Integer errorCode, Integer errorSubcode,
+        Integer httpStatusCode, String type, String message) {
       if (errorCode == API_EC_PARAM_ACCESS_TOKEN)
         return new FacebookOAuthException(String.valueOf(errorCode), message, errorCode, httpStatusCode);
 
@@ -202,7 +202,7 @@ abstract class BaseFacebookClient {
         return;
 
       throw legacyFacebookExceptionMapper.exceptionForTypeAndMessage(
-        errorObject.getInt(LEGACY_ERROR_CODE_ATTRIBUTE_NAME), httpStatusCode, null,
+        errorObject.getInt(LEGACY_ERROR_CODE_ATTRIBUTE_NAME), null, httpStatusCode, null,
         errorObject.getString(LEGACY_ERROR_MSG_ATTRIBUTE_NAME));
     } catch (JsonException e) {
       throw new FacebookJsonMappingException("Unable to process the Facebook API response", e);

--- a/source/library/com/restfb/DefaultFacebookClient.java
+++ b/source/library/com/restfb/DefaultFacebookClient.java
@@ -136,7 +136,7 @@ public class DefaultFacebookClient extends BaseFacebookClient implements Faceboo
    * API error response 'error' attribute name.
    */
   protected static final String ERROR_ATTRIBUTE_NAME = "error";
-
+  
   /**
    * API error response 'type' attribute name.
    */
@@ -151,6 +151,11 @@ public class DefaultFacebookClient extends BaseFacebookClient implements Faceboo
    * API error response 'code' attribute name.
    */
   protected static final String ERROR_CODE_ATTRIBUTE_NAME = "code";
+  
+  /**
+   * API error response 'error_subcode' attribute name.
+   */
+  protected static final String ERROR_SUBCODE_ATTRIBUTE_NAME = "error_subcode";  
 
   /**
    * Batch API error response 'error' attribute name.
@@ -796,9 +801,13 @@ public class DefaultFacebookClient extends BaseFacebookClient implements Faceboo
       Integer errorCode =
           innerErrorObject.has(ERROR_CODE_ATTRIBUTE_NAME) ? toInteger(innerErrorObject
             .getString(ERROR_CODE_ATTRIBUTE_NAME)) : null;
+      Integer errorSubcode =
+          innerErrorObject.has(ERROR_SUBCODE_ATTRIBUTE_NAME) ? toInteger(innerErrorObject
+            .getString(ERROR_SUBCODE_ATTRIBUTE_NAME)) : null;          
 
       throw graphFacebookExceptionMapper
-        .exceptionForTypeAndMessage(errorCode, httpStatusCode, innerErrorObject.getString(ERROR_TYPE_ATTRIBUTE_NAME),
+        .exceptionForTypeAndMessage(errorCode, errorSubcode, httpStatusCode,
+          innerErrorObject.getString(ERROR_TYPE_ATTRIBUTE_NAME),
           innerErrorObject.getString(ERROR_MESSAGE_ATTRIBUTE_NAME));
     } catch (JsonException e) {
       throw new FacebookJsonMappingException("Unable to process the Facebook API response", e);
@@ -841,7 +850,7 @@ public class DefaultFacebookClient extends BaseFacebookClient implements Faceboo
         return;
 
       throw legacyFacebookExceptionMapper.exceptionForTypeAndMessage(errorObject.getInt(BATCH_ERROR_ATTRIBUTE_NAME),
-        httpStatusCode, null, errorObject.getString(BATCH_ERROR_DESCRIPTION_ATTRIBUTE_NAME));
+        null, httpStatusCode, null, errorObject.getString(BATCH_ERROR_DESCRIPTION_ATTRIBUTE_NAME));
     } catch (JsonException e) {
       throw new FacebookJsonMappingException("Unable to process the Facebook API response", e);
     }
@@ -872,10 +881,10 @@ public class DefaultFacebookClient extends BaseFacebookClient implements Faceboo
      * @see com.restfb.exception.FacebookExceptionMapper#exceptionForTypeAndMessage(java.lang.Integer,
      *      java.lang.Integer, java.lang.String, java.lang.String)
      */
-    public FacebookException exceptionForTypeAndMessage(Integer errorCode, Integer httpStatusCode, String type,
-        String message) {
+    public FacebookException exceptionForTypeAndMessage(Integer errorCode, Integer errorSubcode, 
+        Integer httpStatusCode, String type, String message) {
       if ("OAuthException".equals(type) || "OAuthAccessTokenException".equals(type))
-        return new FacebookOAuthException(type, message, errorCode, httpStatusCode);
+        return new FacebookOAuthException(type, message, errorCode, errorSubcode, httpStatusCode);
 
       if ("QueryParseException".equals(type))
         return new FacebookQueryParseException(type, message, httpStatusCode);

--- a/source/library/com/restfb/exception/FacebookExceptionMapper.java
+++ b/source/library/com/restfb/exception/FacebookExceptionMapper.java
@@ -36,6 +36,8 @@ public interface FacebookExceptionMapper {
    * 
    * @param errorCode
    *          Old REST API exception error code field, e.g. 190.
+   * @param errorSubcode
+   *          Old REST API exception error subcode field, e.g. 459.
    * @param httpStatusCode
    *          The HTTP status code returned by the server, e.g. 500.
    * @param type
@@ -44,5 +46,5 @@ public interface FacebookExceptionMapper {
    *          Graph or Old REST API message field, e.g. "Invalid access token signature."
    * @return An appropriate {@code FacebookException} subclass.
    */
-  FacebookException exceptionForTypeAndMessage(Integer errorCode, Integer httpStatusCode, String type, String message);
+  FacebookException exceptionForTypeAndMessage(Integer errorCode, Integer errorSubcode, Integer httpStatusCode, String type, String message);
 }

--- a/source/library/com/restfb/exception/FacebookOAuthException.java
+++ b/source/library/com/restfb/exception/FacebookOAuthException.java
@@ -43,6 +43,11 @@ public class FacebookOAuthException extends FacebookGraphException {
    * The Facebook API error code.
    */
   private Integer errorCode;
+  
+  /**
+   * The Facebook API error subcode.
+   */
+  private Integer errorSubcode;  
 
   private static final long serialVersionUID = 1L;
 
@@ -59,9 +64,29 @@ public class FacebookOAuthException extends FacebookGraphException {
    *          The HTTP status code returned by the server, e.g. 500.
    */
   public FacebookOAuthException(String errorType, String errorMessage, Integer errorCode, Integer httpStatusCode) {
-    super(errorType, errorMessage, httpStatusCode);
+    this(errorType, errorMessage, errorCode, null, httpStatusCode);
     this.errorCode = errorCode;
   }
+  
+  /**
+   * Creates an exception with the given error type and message.
+   * 
+   * @param errorType
+   *          Value of the Facebook response attribute {@code error.type}.
+   * @param errorMessage
+   *          Value of the Facebook response attribute {@code error.message}.
+   * @param errorCode
+   *          Value of the Facebook response attribute {@code error.code}.
+   * @param errorSubcode
+   *          Value of the Facebook response attribute {@code error.error_subcode}.
+   * @param httpStatusCode
+   *          The HTTP status code returned by the server, e.g. 500.
+   */
+  public FacebookOAuthException(String errorType, String errorMessage, Integer errorCode, Integer errorSubcode, Integer httpStatusCode) {
+    super(errorType, errorMessage, httpStatusCode);
+    this.errorCode = errorCode;
+    this.errorSubcode = errorSubcode;
+  }  
 
   /**
    * Gets the Facebook API error code.
@@ -70,5 +95,14 @@ public class FacebookOAuthException extends FacebookGraphException {
    */
   public Integer getErrorCode() {
     return errorCode;
+  }
+  
+  /**
+   * Gets the Facebook API error subcode.
+   * 
+   * @return The Facebook API error subcode.
+   */  
+  public Integer getErrorSubcode() {
+    return errorSubcode;
   }
 }

--- a/source/test/com/restfb/FacebookClientTest.java
+++ b/source/test/com/restfb/FacebookClientTest.java
@@ -53,6 +53,25 @@ public class FacebookClientTest {
       assertEquals(Integer.valueOf(210), e.getErrorCode());
     }
   }
+  
+  /**
+   * Do we correctly handle the case where FB returns an OAuthException with an error code and subcode?
+   */
+  @Test
+  public void oauthExceptionWithErrorSubcode() {
+    FacebookClient facebookClient =
+        facebookClientWithResponse(new Response(403,
+          "{\"error\":{\"message\":\"App Not Installed\",\"type\":\"OAuthException\",\"code\":190,\"error_subcode\":458}}"));
+
+    try {
+      facebookClient.fetchObject("me", User.class);
+    } catch (FacebookOAuthException e) {
+      assertEquals("App Not Installed", e.getErrorMessage());
+      assertEquals("OAuthException", e.getErrorType());
+      assertEquals(Integer.valueOf(190), e.getErrorCode());
+      assertEquals(Integer.valueOf(458), e.getErrorSubcode());
+    }
+  }  
 
   /**
    * Do we correctly handle the case where FB returns an OAuthException without an error code?


### PR DESCRIPTION
Most of the OAuth errors also return an error_subcode field. Different subcodes require
different recovery tactic, as defined in Facebook's reference:
https://developers.facebook.com/docs/reference/api/errors/

The implementation breaks binary compatibility, as the signature of
FacebookExceptionMapper.exceptionForTypeAndMessage was changed.
