### PR TITLE
Added Fields for comment_replies access and images in comments

### DIFF
--- a/source/library/com/restfb/types/Comment.java
+++ b/source/library/com/restfb/types/Comment.java
@@ -23,10 +23,19 @@
 package com.restfb.types;
 
 import static com.restfb.util.DateUtils.toDateFromLongFormat;
+import static java.util.Collections.unmodifiableList;
 
+import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import com.restfb.Facebook;
+import com.restfb.types.Comment;
+import com.restfb.util.ReflectionUtils;
+import com.restfb.types.FacebookType;
+
+
 
 /**
  * Represents the <a href="http://developers.facebook.com/docs/reference/api/event">Comment Graph API type</a>.
@@ -61,6 +70,13 @@ public class Comment extends FacebookType {
   
   @Facebook("can_comment")
   private boolean canComment;
+  
+  @Facebook("comments")
+  private Replies replies;
+  
+  @Facebook
+  private Attachment attachment;
+      
 
   private static final long serialVersionUID = 2L;
 
@@ -71,6 +87,15 @@ public class Comment extends FacebookType {
    */
   public CategorizedFacebookType getFrom() {
     return from;
+  }
+  
+  /**
+   * Attachment (image) added to a comment.
+   * 
+   * @return Attachment on the comment
+   */
+  public Attachment getAttachment() {
+    return attachment;
   }
 
   /**
@@ -152,4 +177,192 @@ public class Comment extends FacebookType {
   public boolean getCanComment() {
     return canComment;
   }
+  
+  /**
+   * The replies to this comment
+   * 
+   * @return replies
+   */
+  public Replies getReplies() {
+    return replies;
+  }
+  
+  
+  
+  /**
+   * Represents the Replies to a Comment</a>.
+   * 
+   * @author <a href="http://ityx.de">Jan Schweizer</a>
+   */
+  public static class Replies implements Serializable {
+    @Facebook
+    private Long count;
+
+    @Facebook
+    private List<Comment> data = new ArrayList<Comment>();
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+      return ReflectionUtils.hashCode(this);
+    }
+
+    /**
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object that) {
+      return ReflectionUtils.equals(this, that);
+    }
+
+    /**
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+      return ReflectionUtils.toString(this);
+    }
+
+    /**
+     * The number of comments.
+     * 
+     * @return The number of comments.
+     */
+    public Long getCount() {
+      return count;
+    }
+
+    /**
+     * The comments.
+     * 
+     * @return The comments.
+     */
+    public List<Comment> getData() {
+      return unmodifiableList(data);
+    }
+  }
+  
+  /**
+   * Media data as applicable for the attachment 
+   * @author <a href="http://ityx.de">Jan Schweizer</a>
+   */
+  public static class MediaData extends FacebookType {
+    
+    @Facebook
+    private Image image;
+    
+    public Image getImage() {
+      return image;
+    }
+
+    public void setImage(Image image) {
+      this.image = image;
+    }
+
+    private static final long serialVersionUID = 1L;  
+
+  }
+ 
+
+  /**
+   * Contains the attachment data for a specific comment (like an image or such)
+   * 
+   * @Author <a href="http://ityx.de">Jan Schweizer</a>
+   */
+  public static class Attachment extends FacebookType {
+
+    public String getUrl() {
+      return url;
+    }
+
+    public void setUrl(String url) {
+      this.url = url;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public void setType(String type) {
+      this.type = type;
+    }
+
+    public MediaData getMediaData() {
+      return mediaData;
+    }
+
+    public void setMediaData(MediaData mediaData) {
+      this.mediaData = mediaData;
+    }
+    @Facebook
+    private String url;
+
+    @Facebook
+    private String type;
+
+    @Facebook("media")
+    private MediaData mediaData;
+    /**
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+      return ReflectionUtils.hashCode(this);
+    }
+
+    /**
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object that) {
+      return ReflectionUtils.equals(this, that);
+    }
+
+    /**
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+      return ReflectionUtils.toString(this);
+    }
+  }
+    
+    /**
+     * Image data as applicable for the attachment 
+     * @author <a href="http://ityx.de">Jan Schweizer</a>
+     */
+    public static class Image extends FacebookType {
+      
+      private static final long serialVersionUID = 1L;  
+            
+      @Facebook
+      int height;
+      @Facebook
+      int width;
+      @Facebook
+      String src;
+      public int getHeight() {
+        return height;
+      }
+      public void setHeight(int height) {
+        this.height = height;
+      }
+      public int getWidth() {
+        return width;
+      }
+      public void setWidth(int width) {
+        this.width = width;
+      }
+      public String getSrc() {
+        return src;
+      }
+      public void setSrc(String src) {
+        this.src = src;
+      }    
+    }
+
 }

--- a/source/library/com/restfb/types/Message.java
+++ b/source/library/com/restfb/types/Message.java
@@ -25,11 +25,13 @@ package com.restfb.types;
 import static com.restfb.util.DateUtils.toDateFromLongFormat;
 import static java.util.Collections.unmodifiableList;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
 import com.restfb.Facebook;
 import com.restfb.util.ReflectionUtils;
+
 
 /**
  * Represents the <a href="http://developers.facebook.com/docs/reference/api/message/">Message Graph API type</a>.
@@ -83,6 +85,9 @@ public class Message extends FacebookType {
 
     @Facebook
     private Long size;
+    
+    @Facebook("image_data")
+    private ImageData image;
 
     /**
      * The size of the attachment in bytes.
@@ -110,6 +115,15 @@ public class Message extends FacebookType {
     public String getMimeType() {
       return mimeType;
     }
+    
+    /**
+     * The attachment's image data
+     * 
+     * @return The attachments image data
+     */
+    public ImageData getImage() {
+      return image;
+    }
 
     /**
      * @see java.lang.Object#hashCode()
@@ -135,6 +149,60 @@ public class Message extends FacebookType {
       return ReflectionUtils.toString(this);
     }
   }
+  
+  /**
+   * Image data included in the attachment 
+   * @author <a href="http://ityx.de">Jan Schweizer</a>
+   */
+  public static class ImageData extends FacebookType {
+    
+    private static final long serialVersionUID = 1L;
+
+    @Facebook
+    private int width;   
+    
+    @Facebook
+    private int height;   
+    
+    @Facebook
+    private String url;   
+    
+    @Facebook
+    private String preview_url;
+
+    public int getWidth() {
+      return width;
+    }
+
+    public void setWidth(int width) {
+      this.width = width;
+    }
+
+    public int getHeight() {
+      return height;
+    }
+
+    public void setHeight(int height) {
+      this.height = height;
+    }
+
+    public String getUrl() {
+      return url;
+    }
+
+    public void setUrl(String url) {
+      this.url = url;
+    }
+
+    public String getPreview_url() {
+      return preview_url;
+    }
+
+    public void setPreview_url(String preview_url) {
+      this.preview_url = preview_url;
+    }   
+  }
+
 
   /**
    * The time the message was initially created.
@@ -205,6 +273,11 @@ public class Message extends FacebookType {
    * @return The attachments associated with the message.
    */
   public List<Attachment> getAttachments() {
-    return unmodifiableList(attachments);
+    //Might be null in which case unmodifiableList fails with NPE
+    if(attachments != null) {
+      return unmodifiableList(attachments);
+    } else {
+      return Collections.emptyList();
+    }
   }
 }


### PR DESCRIPTION
This patch includes a fix on a possible NPE when accessing attachments on a message that didn't have any as well as handling of comment-replies (if the Graph query did return them that is)
