### PR TITLE
Add contentType to BinaryAttachment which will be used to send along wit...

### DIFF
--- a/source/library/com/restfb/BinaryAttachment.java
+++ b/source/library/com/restfb/BinaryAttachment.java
@@ -40,6 +40,7 @@ import com.restfb.util.ReflectionUtils;
 public class BinaryAttachment {
   private String filename;
   private InputStream data;
+  private String contentType = null;
 
   /**
    * Creates a new binary attachment.
@@ -62,6 +63,32 @@ public class BinaryAttachment {
   }
 
   /**
+   * Creates a new binary attachment.
+   *
+   * @param filename
+   *          The attachment's filename.
+   * @param data
+   *          The attachment's data.
+   * @param contentType
+   *          The attachment's contentType.
+   * @throws IllegalArgumentException
+   *           If {@code data} is {@code null} or {@code filename} is {@code null} or blank.
+   */
+  protected BinaryAttachment(String filename, InputStream data, String contentType) {
+    if (isBlank(filename))
+      throw new IllegalArgumentException("Binary attachment filename cannot be blank.");
+    if (data == null)
+      throw new IllegalArgumentException("Binary attachment data cannot be null.");
+    if (isBlank(contentType)) {
+      throw new IllegalArgumentException("ContentType cannot be null.");
+    }
+
+    this.filename = filename;
+    this.data = data;
+    this.contentType = contentType;
+  }
+
+  /**
    * Creates a binary attachment.
    * 
    * @param filename
@@ -74,6 +101,23 @@ public class BinaryAttachment {
    */
   public static BinaryAttachment with(String filename, InputStream data) {
     return new BinaryAttachment(filename, data);
+  }
+
+  /**
+   * Creates a binary attachment.
+   *
+   * @param filename
+   *          The attachment's filename.
+   * @param data
+   *          The attachment's data.
+   * @param contentType
+   *          The attachment's contentType.
+   * @return A binary attachment.
+   * @throws IllegalArgumentException
+   *           If {@code data} is {@code null} or {@code filename} is {@code null} or blank.
+   */
+  public static BinaryAttachment with(String filename, InputStream data, String contentType) {
+    return new BinaryAttachment(filename, data, contentType);
   }
 
   /**
@@ -116,5 +160,14 @@ public class BinaryAttachment {
    */
   public InputStream getData() {
     return data;
+  }
+
+  /**
+   * The attachment's content type.
+   *
+   * @return The attachment's contentType.
+   */
+  public String getContentType() {
+    return this.contentType;
   }
 }

--- a/source/library/com/restfb/DefaultWebRequestor.java
+++ b/source/library/com/restfb/DefaultWebRequestor.java
@@ -171,11 +171,17 @@ public class DefaultWebRequestor implements WebRequestor {
       // Otherwise the body is the URL parameter string.
       if (binaryAttachments.length > 0) {
         for (BinaryAttachment binaryAttachment : binaryAttachments) {
-          outputStream
-            .write((MULTIPART_TWO_HYPHENS + MULTIPART_BOUNDARY + MULTIPART_CARRIAGE_RETURN_AND_NEWLINE
-                + "Content-Disposition: form-data; name=\"" + createFormFieldName(binaryAttachment) + "\"; filename=\""
-                + binaryAttachment.getFilename() + "\"" + MULTIPART_CARRIAGE_RETURN_AND_NEWLINE + MULTIPART_CARRIAGE_RETURN_AND_NEWLINE)
-              .getBytes(ENCODING_CHARSET));
+          StringBuilder sb = new StringBuilder();
+
+          sb.append(MULTIPART_TWO_HYPHENS).append(MULTIPART_BOUNDARY).append(MULTIPART_CARRIAGE_RETURN_AND_NEWLINE).
+              append("Content-Disposition: form-data; name=\"").append(createFormFieldName(binaryAttachment)).
+              append("\"; filename=\"").append(binaryAttachment.getFilename()).append("\"");
+          if (binaryAttachment.getContentType() != null && binaryAttachment.getContentType().length() > 0) {
+            sb.append(MULTIPART_CARRIAGE_RETURN_AND_NEWLINE).append("Content-Type: ").append(binaryAttachment.getContentType());
+          }
+          sb.append(MULTIPART_CARRIAGE_RETURN_AND_NEWLINE).append(MULTIPART_CARRIAGE_RETURN_AND_NEWLINE);
+
+          outputStream.write(sb.toString().getBytes(ENCODING_CHARSET));
 
           write(binaryAttachment.getData(), outputStream, MULTIPART_DEFAULT_BUFFER_SIZE);
 


### PR DESCRIPTION
...h POST requests if it's not null.

The issue was that if there is no content type specified in POST body, then Facebook cannot recogonize it. Esp when you send a picture in private message, the picture will be showed as a file in attachment instead of rendering in the conversation directly.
