### PR TITLE
Event can contain multiple venues. Venue can contain 'name' property

### DIFF
--- a/source/library/com/restfb/types/Event.java
+++ b/source/library/com/restfb/types/Event.java
@@ -57,7 +57,10 @@ public class Event extends NamedFacebookType {
   @Facebook("rsvp_status")
   private String rsvpStatus;
 
-  @Facebook
+  @Facebook("venue")
+  private List<Venue> venueList;
+
+  @Facebook("venue")
   private Venue venue;
 
   @Facebook
@@ -337,4 +340,9 @@ public class Event extends NamedFacebookType {
   public Boolean getIsDateOnly() {
     return isDateOnly;
   }
+
+  public List<Venue> getVenueList() {
+    return venueList;
+  }
+
 }

--- a/source/library/com/restfb/types/Venue.java
+++ b/source/library/com/restfb/types/Venue.java
@@ -58,6 +58,9 @@ public class Venue implements Serializable {
   @Facebook
   private Double longitude;
 
+  @Facebook
+  private String name;
+
   private static final long serialVersionUID = 1L;
 
   /**
@@ -156,4 +159,14 @@ public class Venue implements Serializable {
   public Double getLongitude() {
     return longitude;
   }
+
+  /**
+   * If a venue could not be resolved by facebook, the venue just gets the name of the location
+   * 
+   * @return
+   */
+  public String getName() {
+    return name;
+  }
+
 }

--- a/source/test/com/restfb/JsonMapperToJavaTest.java
+++ b/source/test/com/restfb/JsonMapperToJavaTest.java
@@ -42,6 +42,7 @@ import com.restfb.exception.FacebookJsonMappingException;
 import com.restfb.json.JsonObject;
 import com.restfb.types.Account;
 import com.restfb.types.Conversation;
+import com.restfb.types.Event;
 import com.restfb.types.Message;
 import com.restfb.types.NamedFacebookType;
 import com.restfb.types.Post;
@@ -355,6 +356,25 @@ public class JsonMapperToJavaTest extends AbstractJsonMapperTests {
     } catch (FacebookJsonMappingException e) {
       // Expected
     }
+  }
+
+  @Test
+  public void testJsonToEventWithMultipleVenue() {
+    String theJson = "{\"venue\": [{\"name\": \"venue1\"}, {\"name\": \"venue2\"} ]} ";
+    JsonMapper jsonMapper = createJsonMapper();
+    Event theEvent = jsonMapper.toJavaObject(theJson, Event.class);
+    Assert.assertEquals(2, theEvent.getVenueList().size());
+    Assert.assertEquals("venue1", theEvent.getVenueList().get(0).getName());
+    Assert.assertEquals("venue2", theEvent.getVenueList().get(1).getName());
+  }
+
+  @Test
+  public void testJsonToEventWithSingleVenue() {
+    String theJson = "{\"venue\": {\"name\": \"home\"}}";
+
+    JsonMapper jsonMapper = createJsonMapper();
+    Event theEvent = jsonMapper.toJavaObject(theJson, Event.class);
+    Assert.assertEquals("home", theEvent.getVenue().getName());
   }
 
   static class Story {


### PR DESCRIPTION
Fixed the following issues I had:
- I had a json parsing error when fetching an event from facebook which had no location specified.  Seems that in that case the venue is an empty array '[]'.  --> Added property 'venueList' to Event.
- When the location of an event could not be resolved by facebook, the venue gets a property 'name' with name of the location.  --> Added property 'name' to Venue.
