### PR TITLE
NoIssue - deprecate the methods accepting an InputStream and add equivalents accepting byte[] instead

### DIFF
--- a/source/library/com/restfb/BinaryAttachment.java
+++ b/source/library/com/restfb/BinaryAttachment.java
@@ -22,12 +22,15 @@
 
 package com.restfb;
 
-import static com.restfb.util.StringUtils.isBlank;
-import static java.lang.String.format;
-
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
+import lombok.Getter;
+
 import com.restfb.util.ReflectionUtils;
+
+import static com.restfb.util.StringUtils.isBlank;
+import static java.lang.String.format;
 
 /**
  * Represents a binary file that can be uploaded to Facebook.
@@ -38,8 +41,11 @@ import com.restfb.util.ReflectionUtils;
  * @since 1.6.5
  */
 public class BinaryAttachment {
+  @Getter
   private String filename;
-  private InputStream data;
+  private byte[] data;
+  private InputStream dataStream;
+  @Getter
   private String contentType = null;
 
   /**
@@ -51,7 +57,9 @@ public class BinaryAttachment {
    *          The attachment's data.
    * @throws IllegalArgumentException
    *           If {@code data} is {@code null} or {@code filename} is {@code null} or blank.
+   * @deprecated use the stream-less API passing a {@code byte[]} for data          
    */
+  @Deprecated
   protected BinaryAttachment(String filename, InputStream data) {
     if (isBlank(filename))
       throw new IllegalArgumentException("Binary attachment filename cannot be blank.");
@@ -59,7 +67,7 @@ public class BinaryAttachment {
       throw new IllegalArgumentException("Binary attachment data cannot be null.");
 
     this.filename = filename;
-    this.data = data;
+    this.dataStream = data;
   }
 
   /**
@@ -74,19 +82,16 @@ public class BinaryAttachment {
    * @throws IllegalArgumentException
    *           If {@code data} is {@code null}, {@code filename} is {@code null} or blank, or {@code contentType} is
    *           {@code null} or blank.
+   * @deprecated use the stream-less API passing a {@code byte[]} for data
    * @since 1.6.13
    */
+  @Deprecated
   protected BinaryAttachment(String filename, InputStream data, String contentType) {
-    if (isBlank(filename))
-      throw new IllegalArgumentException("Binary attachment filename cannot be blank.");
-    if (data == null)
-      throw new IllegalArgumentException("Binary attachment data cannot be null.");
+    this(filename, data);
     if (isBlank(contentType)) {
       throw new IllegalArgumentException("ContentType cannot be null.");
     }
-
-    this.filename = filename;
-    this.data = data;
+    
     this.contentType = contentType;
   }
 
@@ -100,7 +105,9 @@ public class BinaryAttachment {
    * @return A binary attachment.
    * @throws IllegalArgumentException
    *           If {@code data} is {@code null} or {@code filename} is {@code null} or blank.
+   * @deprecated use the stream-less API passing a {@code byte[]} for data
    */
+  @Deprecated
   public static BinaryAttachment with(String filename, InputStream data) {
     return new BinaryAttachment(filename, data);
   }
@@ -117,8 +124,88 @@ public class BinaryAttachment {
    * @return A binary attachment.
    * @throws IllegalArgumentException
    *           If {@code data} is {@code null} or {@code filename} is {@code null} or blank.
+   * @deprecated use the stream-less API passing a {@code byte[]} for data instead
    */
+  @Deprecated
   public static BinaryAttachment with(String filename, InputStream data, String contentType) {
+    return new BinaryAttachment(filename, data, contentType);
+  }
+  
+  /**
+   * Creates a new binary attachment.
+   * 
+   * @param filename
+   *          The attachment's filename.
+   * @param data
+   *          The attachment's data.
+   * @throws IllegalArgumentException
+   *           If {@code data} is {@code null} or {@code filename} is {@code null} or blank.
+   * @since 1.6.17
+   */
+  protected BinaryAttachment(String filename, byte[] data) {
+    if (isBlank(filename))
+      throw new IllegalArgumentException("Binary attachment filename cannot be blank.");
+    if (data == null)
+      throw new IllegalArgumentException("Binary attachment data cannot be null.");
+    
+    this.filename = filename;
+    this.data = data;
+  }
+  
+  /**
+   * Creates a new binary attachment.
+   * 
+   * @param filename
+   *          The attachment's filename.
+   * @param data
+   *          The attachment's data.
+   * @param contentType
+   *          The attachment's contentType.
+   * @throws IllegalArgumentException
+   *           If {@code data} is {@code null}, {@code filename} is {@code null} or blank, or {@code contentType} is
+   *           {@code null} or blank.
+   * @since 1.6.17
+   */
+  protected BinaryAttachment(String filename, byte[] data, String contentType) {
+    this(filename, data);
+    if (isBlank(contentType)) {
+      throw new IllegalArgumentException("ContentType cannot be null.");
+    }
+    
+    this.contentType = contentType;
+  }
+  
+  /**
+   * Creates a binary attachment.
+   * 
+   * @param filename
+   *          The attachment's filename.
+   * @param data
+   *          The attachment's data.
+   * @return A binary attachment.
+   * @throws IllegalArgumentException
+   *           If {@code data} is {@code null} or {@code filename} is {@code null} or blank.
+   * @since 1.6.17
+   */
+  public static BinaryAttachment with(String filename, byte[] data) {
+    return new BinaryAttachment(filename, data);
+  }
+  
+  /**
+   * Creates a binary attachment.
+   * 
+   * @param filename
+   *          The attachment's filename.
+   * @param data
+   *          The attachment's data.
+   * @param contentType
+   *          The attachment's contentType.
+   * @return A binary attachment.
+   * @throws IllegalArgumentException
+   *           If {@code data} is {@code null} or {@code filename} is {@code null} or blank.
+   * @since 1.6.17
+   */
+  public static BinaryAttachment with(String filename, byte[] data, String contentType) {
     return new BinaryAttachment(filename, data, contentType);
   }
 
@@ -147,29 +234,17 @@ public class BinaryAttachment {
   }
 
   /**
-   * The attachment's filename.
-   * 
-   * @return The attachment's filename.
-   */
-  public String getFilename() {
-    return filename;
-  }
-
-  /**
    * The attachment's data.
    * 
    * @return The attachment's data.
    */
   public InputStream getData() {
-    return data;
-  }
-
-  /**
-   * The attachment's content type.
-   * 
-   * @return The attachment's contentType.
-   */
-  public String getContentType() {
-    return this.contentType;
+    if (data != null) {
+      return new ByteArrayInputStream(data);
+    } else if (dataStream != null) {
+      return dataStream;
+    } else {
+      throw new IllegalStateException("Either the byte[] or the stream mustn't be null at this point.");
+    }
   }
 }


### PR DESCRIPTION
Answering https://groups.google.com/forum/#!topic/restfb/fY1ssk62Gls made me realize that `BinaryAttachment` has an odd API. IMO methods should neither accept nor return input/output streams - particularly if they're public library methods. Streams are something extremely fragile (they're serializable for one) and great care must be taken ensure that it's clear who manages the stream's lifecycle. Whichever piece of code creates the streams is responsible for closing it.
If I pass an `InputStream` to the `BinaryAttachment` constructor I effectively give up control over the stream's lifecycle. Even if RestFB behaves nicely and doesn't harm the stream it's still not clear for the callee in which state the stream is once RestFB is done.

While we keep both the old and new methods `BinaryAttachment.getData()` is a bit ugly. As soon as the deprecated methods are removed (with 1.7?) that method can be replaced with a Lombok `@Getter` and `DefaultWebRequestor.executePost(String, String, BinaryAttachment...)`/`DefaultWebRequestor.write(InputStream, OutputStream, int)` need to be slightly adjusted.

Let me know what you think of this proposal.
