### PR TITLE
Add title and description in comment's attachment.

### DIFF
--- a/source/library/com/restfb/types/Comment.java
+++ b/source/library/com/restfb/types/Comment.java
@@ -314,6 +314,16 @@ public class Comment extends FacebookType {
 
     @Getter
     @Setter
+    @Facebook
+    private String title;
+
+    @Getter
+    @Setter
+    @Facebook
+    private String description;
+
+    @Getter
+    @Setter
     @Facebook("media")
     private Media media;
 

--- a/source/library/com/restfb/types/Post.java
+++ b/source/library/com/restfb/types/Post.java
@@ -320,6 +320,19 @@ public class Post extends NamedFacebookType {
   @Facebook("admin_creator")
   private NamedFacebookType adminCreator;
 
+  /**
+   * Whether this post is hidden. The original poster can still see the post, along with the page admin and anyone
+   * else tagged in the post (for page only)
+   *
+   * @return is_hidden
+   * @since 1.12.0
+   */
+  @Getter
+  @Setter
+  @Facebook("is_hidden")
+  private Boolean isHidden;
+
+
   private static final long serialVersionUID = 3L;
 
   /**


### PR DESCRIPTION
Hi,
I would like to add these two fields in attachment object for a comment. 
Furthemore, on https://developers.facebook.com/docs/graph-api/reference/v2.3/story_attachment, we could see that Post and Comment use the same object for attachments, there's a reason to have different objects ?

Please let me know if my pull request doesn't respect your guidelines.
Regards