### PR TITLE
Add StoryAttachment type, and add a field to post for attachments.

### DIFF
--- a/source/library/com/restfb/types/Comment.java
+++ b/source/library/com/restfb/types/Comment.java
@@ -1,16 +1,16 @@
 /*
  * Copyright (c) 2010-2015 Mark Allen.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,8 +22,6 @@
 
 package com.restfb.types;
 
-import static java.util.Collections.unmodifiableList;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
@@ -33,12 +31,13 @@ import com.restfb.Facebook;
 import com.restfb.JsonMapper.JsonMappingCompleted;
 import static com.restfb.util.DateUtils.toDateFromLongFormat;
 import com.restfb.util.ReflectionUtils;
+import static java.util.Collections.unmodifiableList;
 import lombok.Getter;
 import lombok.Setter;
 
 /**
  * Represents the <a href="http://developers.facebook.com/docs/reference/api/event">Comment Graph API type</a>.
- * 
+ *
  * @author <a href="http://restfb.com">Mark Allen</a>
  * @since 1.5
  */
@@ -46,7 +45,7 @@ public class Comment extends FacebookType {
 
   /**
    * User who posted the comment.
-   * 
+   *
    * @return User who posted the comment.
    */
   @Getter
@@ -56,7 +55,7 @@ public class Comment extends FacebookType {
 
   /**
    * Text contents of the comment.
-   * 
+   *
    * @return Text contents of the comment.
    */
   @Getter
@@ -69,7 +68,7 @@ public class Comment extends FacebookType {
 
   /**
    * Date on which the comment was created.
-   * 
+   *
    * @return Date on which the comment was created.
    */
   @Getter
@@ -78,7 +77,7 @@ public class Comment extends FacebookType {
 
   /**
    * The number of likes on this comment.
-   * 
+   *
    * @return The number of likes on this comment.
    * @deprecated As of September 5, 2012, Facebook is changing over to {@code like_count}, so this method will be
    *             replaced by {@link #likeCount}.
@@ -90,7 +89,7 @@ public class Comment extends FacebookType {
 
   /**
    * The number of likes on this comment.
-   * 
+   *
    * @return The number of likes on this comment.
    * @since 1.6.10
    */
@@ -101,7 +100,7 @@ public class Comment extends FacebookType {
 
   /**
    * Number of replies to this comment.
-   * 
+   *
    * @return Number of replies to this comment
    */
   @Getter
@@ -111,7 +110,7 @@ public class Comment extends FacebookType {
 
   /**
    * This field is returned only if the authenticated user can remove this comment.
-   * 
+   *
    * @return This field is returned only if the authenticated user can remove this comment.
    * @since 1.6.10
    */
@@ -122,7 +121,7 @@ public class Comment extends FacebookType {
 
   /**
    * This field is returned only if the authenticated user likes this comment
-   * 
+   *
    * @return This field is returned only if the authenticated user likes this comment.
    * @since 1.6.10
    */
@@ -133,7 +132,7 @@ public class Comment extends FacebookType {
 
   /**
    * If this comment is a reply, this field returns the parent comment, otherwise no value
-   * 
+   *
    * @return the parent Comment
    * @since 1.6.13
    */
@@ -144,7 +143,7 @@ public class Comment extends FacebookType {
 
   /**
    * Specifies whether you can reply to this comment
-   * 
+   *
    * @return can_comment
    * @since 1.6.13
    */
@@ -155,7 +154,7 @@ public class Comment extends FacebookType {
 
   /**
    * Whether the viewer can hide this comment
-   * 
+   *
    * @return can_hide
    * @since 1.7.1
    */
@@ -167,7 +166,7 @@ public class Comment extends FacebookType {
   /**
    * Whether this comment is hidden. The original poster can still see the comment, along with the page admin and anyone
    * else tagged in the comment
-   * 
+   *
    * @return is_hidden
    * @since 1.7.1
    */
@@ -178,7 +177,7 @@ public class Comment extends FacebookType {
 
   /**
    * Parent object this comment was made on.
-   * 
+   *
    * @return object
    * @since 1.7.1
    */
@@ -189,7 +188,7 @@ public class Comment extends FacebookType {
 
   /**
    * The replies to this comment
-   * 
+   *
    * @return replies
    */
   @Getter
@@ -199,10 +198,10 @@ public class Comment extends FacebookType {
 
   /**
    * Attachment (image) added to a comment.
-   * 
+   *
    * To force Facebook to fill the <code>attachment</code> field you have to fetch the comment with the
    * <code>fields=attachment</code> parameter, otherwise the attachments are <code>null</code>.
-   * 
+   *
    * @return Attachment on the comment
    */
   @Getter
@@ -219,14 +218,14 @@ public class Comment extends FacebookType {
 
   /**
    * Represents the Replies to a Comment</a>.
-   * 
+   *
    * @author <a href="http://ityx.de">Jan Schweizer</a>
    */
   public static class Comments implements Serializable {
 
     /**
      * The number of comments.
-     * 
+     *
      * @return The number of comments.
      */
     @Getter
@@ -265,7 +264,7 @@ public class Comment extends FacebookType {
 
     /**
      * The comments.
-     * 
+     *
      * @return The comments.
      */
     public List<Comment> getData() {
@@ -283,7 +282,7 @@ public class Comment extends FacebookType {
 
   /**
    * Media data as applicable for the attachment.
-   * 
+   *
    * @author <a href="http://ityx.de">Jan Schweizer</a>
    */
   public static class Media extends FacebookType {
@@ -297,7 +296,7 @@ public class Comment extends FacebookType {
 
   /**
    * Contains the attachment data for a specific comment (like an image or such)
-   * 
+   *
    * @author <a href="http://ityx.de">Jan Schweizer</a>
    */
   public static class Attachment extends FacebookType {
@@ -306,6 +305,16 @@ public class Comment extends FacebookType {
     @Setter
     @Facebook
     private String url;
+
+    @Getter
+    @Setter
+    @Facebook
+    private String title;
+
+    @Getter
+    @Setter
+    @Facebook
+    private String description;
 
     @Getter
     @Setter
@@ -344,7 +353,7 @@ public class Comment extends FacebookType {
 
   /**
    * Image data as applicable for the attachment
-   * 
+   *
    * @author <a href="http://ityx.de">Jan Schweizer</a>
    */
   public static class Image extends FacebookType {

--- a/source/library/com/restfb/types/Post.java
+++ b/source/library/com/restfb/types/Post.java
@@ -1,16 +1,16 @@
 /*
  * Copyright (c) 2010-2015 Mark Allen.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21,11 +21,6 @@
  */
 
 package com.restfb.types;
-
-import static com.restfb.json.JsonObject.getNames;
-import static com.restfb.util.DateUtils.toDateFromLongFormat;
-import static java.util.Collections.unmodifiableList;
-import static java.util.Collections.unmodifiableMap;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -38,14 +33,18 @@ import com.restfb.Facebook;
 import com.restfb.JsonMapper;
 import com.restfb.JsonMapper.JsonMappingCompleted;
 import com.restfb.json.JsonObject;
+import static com.restfb.json.JsonObject.getNames;
 import com.restfb.types.Checkin.Place.Location;
+import static com.restfb.util.DateUtils.toDateFromLongFormat;
 import com.restfb.util.ReflectionUtils;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableMap;
 import lombok.Getter;
 import lombok.Setter;
 
 /**
  * Represents the <a href="http://developers.facebook.com/docs/reference/api/post">Post Graph API type</a>.
- * 
+ *
  * @author <a href="http://restfb.com">Mark Allen</a>
  * @since 1.5
  */
@@ -54,7 +53,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * An object containing the ID and name of the user who posted the message.
-   * 
+   *
    * @return An object containing the ID and name of the user who posted the message.
    */
   @Getter
@@ -64,7 +63,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * The message.
-   * 
+   *
    * @return The message.
    */
   @Getter
@@ -74,7 +73,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * If available, a link to the picture included with this post.
-   * 
+   *
    * @return If available, a link to the picture included with this post.
    */
   @Getter
@@ -84,7 +83,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * The link attached to this post.
-   * 
+   *
    * @return The link attached to this post.
    */
   @Getter
@@ -94,7 +93,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * The caption of the link (appears beneath the link name).
-   * 
+   *
    * @return The caption of the link (appears beneath the link name).
    */
   @Getter
@@ -104,7 +103,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * A description of the link (appears beneath the link caption).
-   * 
+   *
    * @return A description of the link (appears beneath the link caption).
    */
   @Getter
@@ -114,7 +113,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * If available, the source link attached to this post (for example, a flash or video file).
-   * 
+   *
    * @return If available, the source link attached to this post (for example, a flash or video file).
    */
   @Getter
@@ -124,7 +123,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * The type of post this is, for example {@code "link"}.
-   * 
+   *
    * @return The type of post this is, for example {@code "link"}.
    */
   @Getter
@@ -134,7 +133,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * The application used to create this post.
-   * 
+   *
    * @return The application used to create this post.
    */
   @Getter
@@ -144,7 +143,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * A link to an icon representing the type of this post.
-   * 
+   *
    * @return A link to an icon representing the type of this post.
    */
   @Getter
@@ -154,7 +153,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * A string indicating which application was used to create this post.
-   * 
+   *
    * @return A string indicating which application was used to create this post.
    */
   @Getter
@@ -164,7 +163,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * The privacy settings for this post.
-   * 
+   *
    * @return The privacy settings for this post.
    */
   @Getter
@@ -174,11 +173,11 @@ public class Post extends NamedFacebookType {
 
   /**
    * Object that controls news feed targeting for this post.
-   * 
+   *
    * To force Facebook to fill the <code>feed_targeting</code> field you have to fetch the post with the
    * <code>fields=feed_targeting</code> parameter, otherwise the feedTargeting is <code>null</code>.
-   * 
-   * 
+   *
+   *
    * @since 1.11.0
    */
   @Getter
@@ -194,13 +193,13 @@ public class Post extends NamedFacebookType {
 
   /**
    * Duplicate mapping for "likes" since FB can return it differently in different situations.
-   * 
+   *
    * -- GETTER -- The likes on this post.
    * <p>
    * Sometimes this can be {@code null} - check {@link #getLikesCount()} instead in that case.
-   * 
+   *
    * @return The likes on this post.
-   * 
+   *
    */
   @Getter
   @Setter
@@ -212,7 +211,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * The time the post was initially published.
-   * 
+   *
    * @return The time the post was initially published.
    */
   @Getter
@@ -224,7 +223,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * The time of the last comment on this post.
-   * 
+   *
    * @return The time of the last comment on this post.
    */
   @Getter
@@ -233,7 +232,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * The Facebook object id for an uploaded photo or video.
-   * 
+   *
    * @return The Facebook object id for an uploaded photo or video.
    * @since 1.6.5
    */
@@ -244,7 +243,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * The {@code status_type} of post this is, for example {@code "approved_friend"}.
-   * 
+   *
    * @return The {@code status_type} of post this is, for example {@code "approved_friend"}.
    * @since 1.6.12
    */
@@ -255,7 +254,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * Text from stories not intentionally generated by users
-   * 
+   *
    * @return Text from stories not intentionally generated by users
    * @since 1.6.16
    */
@@ -266,7 +265,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * The comments for this post.
-   * 
+   *
    * @return The comments for this post.
    */
   @Getter
@@ -276,7 +275,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * The place where this post occurred.
-   * 
+   *
    * @return The place where this post occurred.
    * @since 1.6.8
    */
@@ -309,9 +308,9 @@ public class Post extends NamedFacebookType {
 
   /**
    * ID of admin who created the post.
-   * 
+   *
    * Applies to pages only
-   * 
+   *
    * @return ID of admin who created the post.
    * @since 1.10.0
    */
@@ -343,6 +342,19 @@ public class Post extends NamedFacebookType {
   @Facebook("is_published")
   private Boolean isPublished;
 
+  /**
+   * Attachments added to a post.
+   *
+   * To force Facebook to fill the <code>attachments</code> field you have to fetch the post with the
+   * <code>fields=attachments</code> parameter, otherwise the attachments are <code>null</code>.
+   *
+   * @return Attachment on the post
+   */
+  @Getter
+  @Setter
+  @Facebook
+  private Attachments attachments;
+
   private static final long serialVersionUID = 3L;
 
   /**
@@ -350,7 +362,7 @@ public class Post extends NamedFacebookType {
    * <p>
    * This is a temporary hack until we have formal public support for it/improved {@code JsonMapper} capabilities so it
    * can handle arbitrary Map types.
-   * 
+   *
    * @param jsonMapper
    *          The {@code JsonMapper} that was used to map to this type.
    * @since 1.6.11
@@ -371,7 +383,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * Represents the <a href="http://developers.facebook.com/docs/reference/api/post">Place Graph API type</a>.
-   * 
+   *
    * @author <a href="http://restfb.com">Mark Allen</a>
    * @since 1.6.8
    * @deprecated As of release 1.6.10, replaced by {@link Location}.
@@ -381,7 +393,7 @@ public class Post extends NamedFacebookType {
 
     /**
      * The location of this place.
-     * 
+     *
      * @return The location of this place.
      */
     @Getter
@@ -395,7 +407,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * Represents the <a href="http://developers.facebook.com/docs/reference/api/post">Message Tag Graph API type</a>.
-   * 
+   *
    * @author <a href="http://restfb.com">Mark Allen</a>
    * @since 1.6.10
    */
@@ -403,7 +415,7 @@ public class Post extends NamedFacebookType {
 
     /**
      * The offset, within the message field, of the object mentioned.
-     * 
+     *
      * @return The offset, within the message field, of the object mentioned.
      */
     @Getter
@@ -413,7 +425,7 @@ public class Post extends NamedFacebookType {
 
     /**
      * The length, within the message field, of the object mentioned.
-     * 
+     *
      * @return The length, within the message field, of the object mentioned.
      */
     @Getter
@@ -427,7 +439,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * Represents the undocumented {@code Property} type.
-   * 
+   *
    * @author <a href="http://restfb.com">Mark Allen</a>
    * @since 1.6.4
    */
@@ -435,7 +447,7 @@ public class Post extends NamedFacebookType {
 
     /**
      * The name of the property.
-     * 
+     *
      * @return The name of the property.
      */
     @Getter
@@ -445,7 +457,7 @@ public class Post extends NamedFacebookType {
 
     /**
      * The text of the property.
-     * 
+     *
      * @return The text of the property.
      */
     @Getter
@@ -455,7 +467,7 @@ public class Post extends NamedFacebookType {
 
     /**
      * The URL of the property.
-     * 
+     *
      * @return The URL of the property.
      */
     @Getter
@@ -493,7 +505,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * Represents the <a href="http://developers.facebook.com/docs/reference/api/post">Likes Graph API type</a>
-   * 
+   *
    * @author <a href="http://restfb.com">Mark Allen</a>
    * @since 1.6
    */
@@ -501,7 +513,7 @@ public class Post extends NamedFacebookType {
 
     /**
      * The number of likes.
-     * 
+     *
      * @return The number of likes.
      */
     @Getter
@@ -543,7 +555,7 @@ public class Post extends NamedFacebookType {
 
     /**
      * The likes.
-     * 
+     *
      * @return The likes.
      */
     public List<NamedFacebookType> getData() {
@@ -571,12 +583,12 @@ public class Post extends NamedFacebookType {
 
   /**
    * Represents the <a href="http://developers.facebook.com/docs/reference/api/post">Comments Graph API type</a>.
-   * 
+   *
    * <p>
    * Please request '{id}/comments?summary=true' explicitly if you would like the summary field which contains the count
    * (now called 'total_count')
    * </p>
-   * 
+   *
    * @author <a href="http://restfb.com">Mark Allen</a>
    * @since 1.5.3
    */
@@ -584,12 +596,12 @@ public class Post extends NamedFacebookType {
 
     /**
      * The number of comments.
-     * 
+     *
      * <p>
      * Please request '{id}/comments?summary=true' explicitly if you would like the summary field which contains the
      * count (now called 'total_count')
      * </p>
-     * 
+     *
      * @return The number of comments.
      */
     @Getter
@@ -631,7 +643,7 @@ public class Post extends NamedFacebookType {
 
     /**
      * The comments.
-     * 
+     *
      * @return The comments.
      */
     public List<Comment> getData() {
@@ -660,7 +672,7 @@ public class Post extends NamedFacebookType {
   /**
    * Represents the <a href="https://developers.facebook.com/docs/reference/api/privacy-parameter/">Privacy Graph API
    * type</a>.
-   * 
+   *
    * @author <a href="http://restfb.com">Mark Allen</a>
    * @since 1.5
    */
@@ -668,7 +680,7 @@ public class Post extends NamedFacebookType {
 
     /**
      * The description of the privacy value.
-     * 
+     *
      * @return The description of the privacy value.
      */
     @Getter
@@ -678,7 +690,7 @@ public class Post extends NamedFacebookType {
 
     /**
      * The privacy description.
-     * 
+     *
      * @return The privacy description.
      */
     @Getter
@@ -688,7 +700,7 @@ public class Post extends NamedFacebookType {
 
     /**
      * The privacy friends restriction.
-     * 
+     *
      * @return The privacy friends restriction.
      */
     @Getter
@@ -698,7 +710,7 @@ public class Post extends NamedFacebookType {
 
     /**
      * The privacy networks restriction.
-     * 
+     *
      * @return The privacy networks restriction.
      */
     @Getter
@@ -708,7 +720,7 @@ public class Post extends NamedFacebookType {
 
     /**
      * For CUSTOM settings, a comma-separated list of user IDs and friend list IDs that "cannot" see the post.
-     * 
+     *
      * @return The privacy "deny" restriction.
      */
     @Getter
@@ -719,7 +731,7 @@ public class Post extends NamedFacebookType {
     /**
      * For CUSTOM settings, a comma-separated list of user IDs and friend list IDs that "can" see the post. This can
      * also be ALL_FRIENDS or FRIENDS_OF_FRIENDS to include all members of those sets.
-     * 
+     *
      * @return The privacy "allow" restriction.
      */
     @Getter
@@ -757,7 +769,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * Represents the <a href="http://developers.facebook.com/docs/reference/api/post">Action Graph API type</a>.
-   * 
+   *
    * @author <a href="http://restfb.com">Mark Allen</a>
    * @since 1.5
    */
@@ -765,7 +777,7 @@ public class Post extends NamedFacebookType {
 
     /**
      * Gets the name of the action.
-     * 
+     *
      * @return Gets the name of the action.
      */
     @Getter
@@ -775,7 +787,7 @@ public class Post extends NamedFacebookType {
 
     /**
      * The link for the action.
-     * 
+     *
      * @return The link for the action.
      */
     @Getter
@@ -813,10 +825,10 @@ public class Post extends NamedFacebookType {
 
   /**
    * Object that controls news feed targeting for this post.
-   * 
+   *
    * Anyone in these groups will be more likely to see this post, others will be less likely, but may still see it
    * anyway. Any of the targeting fields shown here can be used, none are required (applies to Pages only).
-   * 
+   *
    * Represents the <a href="http://developers.facebook.com/docs/reference/api/post#fields">Feed Targeting API type</a>.
    */
   public static class FeedTargeting implements Serializable {
@@ -878,9 +890,9 @@ public class Post extends NamedFacebookType {
 
     /**
      * Values of targeting cities.
-     * 
+     *
      * Use type of adcity to find Targeting Options and use the returned key to specify.
-     * 
+     *
      * @return list of cities
      */
     public List<Integer> getCities() {
@@ -897,10 +909,10 @@ public class Post extends NamedFacebookType {
 
     /**
      * Target people who majored in these college subjects.
-     * 
+     *
      * Limited to 200 college major values. Use type of adcollegemajor to find Targeting Options and use the returned
      * name to specify.
-     * 
+     *
      * @return list of college majors
      */
     public List<String> getCollegeMajors() {
@@ -917,9 +929,9 @@ public class Post extends NamedFacebookType {
 
     /**
      * Colleges, for college graduates.
-     * 
+     *
      * Limit is 200 values.
-     * 
+     *
      * @return list of colleges
      */
     public List<FacebookType> getCollegeNetworks() {
@@ -936,7 +948,7 @@ public class Post extends NamedFacebookType {
 
     /**
      * Array of integers for graduation year from college.
-     * 
+     *
      * @return graduation year list
      */
     public List<Integer> getCollegeYears() {
@@ -953,9 +965,9 @@ public class Post extends NamedFacebookType {
 
     /**
      * Values of targeting countries.
-     * 
+     *
      * You can specify up to 25 countries. Use ISO 3166 format codes.
-     * 
+     *
      * @return list of targeting countries.
      */
     public List<String> getCountries() {
@@ -972,9 +984,9 @@ public class Post extends NamedFacebookType {
 
     /**
      * Array of integers for targeting based on education level.
-     * 
+     *
      * Use 1 for high school, 2 for undergraduate, and 3 for alum (or localized equivalents).
-     * 
+     *
      * @return list of education levels
      */
     public List<Integer> getEducationStatuses() {
@@ -991,9 +1003,9 @@ public class Post extends NamedFacebookType {
 
     /**
      * List of object ids.
-     * 
+     *
      * the user should be fan of these objects (interests).
-     * 
+     *
      * @return list of object ids
      */
     public List<String> getFanOf() {
@@ -1010,9 +1022,9 @@ public class Post extends NamedFacebookType {
 
     /**
      * Target specific genders.
-     * 
+     *
      * 1 targets all male viewers and 2 females. Default is to target both.
-     * 
+     *
      * @return list of genders
      */
     public List<Integer> getGenders() {
@@ -1029,11 +1041,11 @@ public class Post extends NamedFacebookType {
 
     /**
      * Indicates targeting based on the 'interested in' field of the user profile.
-     * 
+     *
      * You can specify an integer of 1 to indicate male, 2 indicates female. Default is all types.
-     * 
+     *
      * Please note 'interested in' targeting is not available in France due to local laws.
-     * 
+     *
      * @return list of 'interested in' types
      */
     public List<Integer> getInterestedIn() {
@@ -1050,9 +1062,9 @@ public class Post extends NamedFacebookType {
 
     /**
      * Targeted locales.
-     * 
+     *
      * Use type of adlocale to find Targeting Options and use the returned key to specify.
-     * 
+     *
      * @return list of locales
      */
     public List<Integer> getLocales() {
@@ -1069,9 +1081,9 @@ public class Post extends NamedFacebookType {
 
     /**
      * Values of targeting regions.
-     * 
+     *
      * Use type of adregion to find Targeting Options and use the returned key to specify.
-     * 
+     *
      * @return list of regions
      */
     public List<Integer> getRegions() {
@@ -1088,9 +1100,9 @@ public class Post extends NamedFacebookType {
 
     /**
      * Array of integers for targeting based on relationship status.
-     * 
+     *
      * Use 1 for single, 2 for 'in a relationship', 3 for married, and 4 for engaged. Default is all types.
-     * 
+     *
      * @return list of relationship statuses
      */
     public List<Integer> getRelationshipStatuses() {
@@ -1107,13 +1119,13 @@ public class Post extends NamedFacebookType {
 
     /**
      * Company, organization, or other workplace.
-     * 
+     *
      * <b>Name</b>: Name of targeted workplace. Use type of adworkplace to find Targeting Options and use the returned
      * name to specify this.
-     * 
+     *
      * <b>Id</b>: Unique ID of targeted workplace. Use type of adworkplace to find Targeting Options and use the
      * returned key to specify this (must match paired name value).
-     * 
+     *
      * @return list of work networks
      */
     public List<NamedFacebookType> getWorkNetworks() {
@@ -1147,14 +1159,14 @@ public class Post extends NamedFacebookType {
   /**
    * Represents the Shares included the <a href="http://developers.facebook.com/docs/reference/api/post">Post</a>
    * response. Presently only supports count.
-   * 
+   *
    * @since 1.6.11
    */
   public static class Shares implements Serializable {
 
     /**
      * The number of shares.
-     * 
+     *
      * @return The number of shares.
      */
     @Getter
@@ -1191,8 +1203,69 @@ public class Post extends NamedFacebookType {
   }
 
   /**
+   * Represents the <a href="http://developers.facebook.com/docs/reference/api/post">Place Graph API type</a>.
+   *
+   * @author <a href="https://github.com/kevinleturc/">Kevin Leturc</a>
+   * @since 1.12.0
+   */
+  public static class Attachments extends NamedFacebookType {
+
+    /**
+     * All media attachments associated with this post.
+     *
+     * @return All media attachments associated with this post.
+     */
+    @Facebook
+    private List<StoryAttachment> data = new ArrayList<StoryAttachment>();
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+      return ReflectionUtils.hashCode(this);
+    }
+
+    /**
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object that) {
+      return ReflectionUtils.equals(this, that);
+    }
+
+    /**
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+      return ReflectionUtils.toString(this);
+    }
+
+    /**
+     * The attachments.
+     *
+     * @return The attachments.
+     */
+    public List<StoryAttachment> getData() {
+      return unmodifiableList(data);
+    }
+
+    public boolean addData(StoryAttachment attachment) {
+      return data.add(attachment);
+    }
+
+    public boolean removeData(StoryAttachment attachment) {
+      return data.remove(attachment);
+    }
+
+  }
+
+  /**
    * The number of likes on this post.
-   * 
+   *
    * @return The number of likes on this post.
    */
   public Long getLikesCount() {
@@ -1205,7 +1278,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * The number of shares of this post.
-   * 
+   *
    * @return The number of shares of this post.
    */
   public Long getSharesCount() {
@@ -1217,7 +1290,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * The number of comments of this post.
-   * 
+   *
    * @return The number of comments of this post.
    */
   public Long getCommentsCount() {
@@ -1235,7 +1308,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * A list of the profiles mentioned or targeted in this post.
-   * 
+   *
    * @return A list of the profiles mentioned or targeted in this post.
    */
   public List<NamedFacebookType> getTo() {
@@ -1252,7 +1325,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * A list of available action names and links (including commenting, liking, and an optional app-specified action).
-   * 
+   *
    * @return A list of available action names and links (including commenting, liking, and an optional app-specified
    *         action).
    */
@@ -1272,7 +1345,7 @@ public class Post extends NamedFacebookType {
    * A list of properties for this post.
    * <p>
    * This field is undocumented.
-   * 
+   *
    * @return A list of properties for this post.
    */
   public List<Property> getProperties() {
@@ -1289,7 +1362,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * Objects (Users, Pages, etc) tagged as being with the publisher of the post ("Who are you with?" on Facebook).
-   * 
+   *
    * @return Objects (Users, Pages, etc) tagged as being with the publisher of the post ("Who are you with?" on
    *         Facebook).
    * @since 1.6.10
@@ -1308,7 +1381,7 @@ public class Post extends NamedFacebookType {
 
   /**
    * Objects tagged in the message (Users, Pages, etc).
-   * 
+   *
    * @return Objects tagged in the message (Users, Pages, etc).
    * @since 1.6.10
    */

--- a/source/library/com/restfb/types/StoryAttachment.java
+++ b/source/library/com/restfb/types/StoryAttachment.java
@@ -1,0 +1,299 @@
+package com.restfb.types;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.restfb.Facebook;
+import com.restfb.util.ReflectionUtils;
+import static java.util.Collections.unmodifiableList;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Represents the <a href="https://developers.facebook.com/docs/graph-api/reference/v2.3/story_attachment">Story Attachment Graph API type</a>.
+ *
+ * @author <a href="https://github.com/kevinleturc/">Kevin Leturc</a>
+ * @since 1.12.0
+ */
+public class StoryAttachment extends FacebookType {
+
+  /**
+   * Returns text accompanying the attachment.
+   *
+   * @return Text accompanying the attachment.
+   */
+  @Getter
+  @Setter
+  @Facebook
+  private String description;
+
+  /**
+   * Returns media object (photo, link etc.) contained in the attachment.
+   *
+   * @return Media object (photo, link etc.) contained in the attachment.
+   */
+  @Getter
+  @Setter
+  @Facebook
+  private Media media;
+
+  /**
+   * Returns object that the attachment links to.
+   *
+   * @return Object that the attachment links to.
+   */
+  @Getter
+  @Setter
+  @Facebook
+  private Target target;
+
+  /**
+   * Returns title of the attachment.
+   *
+   * @return Title of the attachment.
+   */
+  @Getter
+  @Setter
+  @Facebook
+  private String title;
+
+  /**
+   * Returns type of the attachment.
+   *
+   * @return Type of the attachment.
+   */
+  @Getter
+  @Setter
+  @Facebook
+  private String type;
+
+  /**
+   * Returns URL of the attachment.
+   *
+   * @return URL of the attachment.
+   */
+  @Getter
+  @Setter
+  @Facebook
+  private String url;
+
+  /**
+   * Returns list of subattachments that are associated with this attachment.
+   *
+   * @return List of subattachments that are associated with this attachment.
+   */
+  @Getter
+  @Setter
+  @Facebook("subattachments")
+  private Attachments subAttachments;
+
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * @see java.lang.Object#hashCode()
+   */
+  @Override
+  public int hashCode() {
+    return ReflectionUtils.hashCode(this);
+  }
+
+  /**
+   * @see java.lang.Object#equals(java.lang.Object)
+   */
+  @Override
+  public boolean equals(Object that) {
+    return ReflectionUtils.equals(this, that);
+  }
+
+  /**
+   * @see java.lang.Object#toString()
+   */
+  @Override
+  public String toString() {
+    return ReflectionUtils.toString(this);
+  }
+
+  /**
+   * Represents the list of subattachments that are associated with this attachment. This will have data if the parent
+   * attachment is a container for multiple other attachments. For example, a multi-photo story will have a parent
+   * attachment representing an upload of multiple photos to an album where each subattachment will contain the actual
+   * photos that were uploaded.
+   *
+   * @author <a href="https://github.com/kevinleturc/">Kevin Leturc</a>
+   */
+  public static class Attachments implements Serializable {
+
+    @Facebook
+    private List<StoryAttachment> data = new ArrayList<StoryAttachment>();
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+      return ReflectionUtils.hashCode(this);
+    }
+
+    /**
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object that) {
+      return ReflectionUtils.equals(this, that);
+    }
+
+    /**
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+      return ReflectionUtils.toString(this);
+    }
+
+    /**
+     * The attachments.
+     *
+     * @return The attachments.
+     */
+    public List<StoryAttachment> getData() {
+      return unmodifiableList(data);
+    }
+
+    public boolean addData(StoryAttachment attachment) {
+      return data.add(attachment);
+    }
+
+    public boolean removeData(StoryAttachment attachment) {
+      return data.remove(attachment);
+    }
+  }
+
+  /**
+   * Media data as applicable for the attachment.
+   *
+   * @author <a href="https://github.com/kevinleturc/">Kevin Leturc</a>
+   */
+  public static class Media extends FacebookType {
+    private static final long serialVersionUID = 1L;
+
+    @Getter
+    @Setter
+    @Facebook
+    private Image image;
+
+    /**
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+      return ReflectionUtils.hashCode(this);
+    }
+
+    /**
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object that) {
+      return ReflectionUtils.equals(this, that);
+    }
+
+    /**
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+      return ReflectionUtils.toString(this);
+    }
+  }
+
+  /**
+   * Image data as applicable for the attachment
+   *
+   * @author <a href="https://github.com/kevinleturc/">Kevin Leturc</a>
+   */
+  public static class Image extends FacebookType {
+    private static final long serialVersionUID = 1L;
+
+    @Getter
+    @Setter
+    @Facebook
+    private Integer height;
+
+    @Getter
+    @Setter
+    @Facebook
+    private Integer width;
+
+    @Getter
+    @Setter
+    @Facebook
+    private String src;
+
+    /**
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+      return ReflectionUtils.hashCode(this);
+    }
+
+    /**
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object that) {
+      return ReflectionUtils.equals(this, that);
+    }
+
+    /**
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+      return ReflectionUtils.toString(this);
+    }
+
+  }
+
+  /**
+   * Target data as applicable for the attachment
+   *
+   * @author <a href="https://github.com/kevinleturc/">Kevin Leturc</a>
+   */
+  public static class Target extends FacebookType {
+
+    @Getter
+    @Setter
+    @Facebook
+    private String url;
+
+    /**
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+      return ReflectionUtils.hashCode(this);
+    }
+
+    /**
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object that) {
+      return ReflectionUtils.equals(this, that);
+    }
+
+    /**
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+      return ReflectionUtils.toString(this);
+    }
+
+  }
+
+}

--- a/source/test/java/com/restfb/types/PostTest.java
+++ b/source/test/java/com/restfb/types/PostTest.java
@@ -6,10 +6,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,7 +22,6 @@ package com.restfb.types;
 
 import com.restfb.AbstractJsonMapperTests;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -108,5 +107,18 @@ public class PostTest extends AbstractJsonMapperTests {
     Post examplePost = createJsonMapper().toJavaObject(jsonFromClasspath("v2_3/post-ishidden"), Post.class);
     assertNotNull(examplePost);
     assertTrue(examplePost.getIsHidden());
+  }
+
+  @Test
+  public void checkV2_3_Attachments() {
+    Post examplePost = createJsonMapper().toJavaObject(jsonFromClasspath("v2_3/post-attachments"), Post.class);
+    assertNotNull(examplePost);
+    assertNotNull(examplePost.getAttachments());
+    assertNotNull(examplePost.getAttachments().getData());
+    assertEquals(1, examplePost.getAttachments().getData().size());
+    assertNotNull(examplePost.getAttachments().getData().get(0));
+    assertNotNull(examplePost.getAttachments().getData().get(0).getSubAttachments());
+    assertNotNull(examplePost.getAttachments().getData().get(0).getSubAttachments().getData());
+    assertEquals(3, examplePost.getAttachments().getData().get(0).getSubAttachments().getData().size());
   }
 }

--- a/source/test/java/com/restfb/types/StoryAttachmentTest.java
+++ b/source/test/java/com/restfb/types/StoryAttachmentTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2010-2015 Norbert Bartels
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.restfb.types;
+
+import java.util.List;
+
+import com.restfb.AbstractJsonMapperTests;
+import com.restfb.types.StoryAttachment.Image;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
+
+public class StoryAttachmentTest extends AbstractJsonMapperTests {
+
+  @Test
+  public void checkImage() {
+    StoryAttachment attachment =
+        createJsonMapper().toJavaObject(jsonFromClasspath("v2_3/story-attachment"), StoryAttachment.class);
+    assertNotNull(attachment.getMedia());
+    Image image = attachment.getMedia().getImage();
+    assertEquals(45, image.getHeight().intValue());
+    assertEquals(175, image.getWidth().intValue());
+  }
+
+  @Test
+  public void checkSubAttachments() {
+    StoryAttachment attachment =
+        createJsonMapper().toJavaObject(jsonFromClasspath("v2_3/story-attachment"), StoryAttachment.class);
+    assertNotNull(attachment.getSubAttachments());
+    List<StoryAttachment> subAttachments = attachment.getSubAttachments().getData();
+    assertEquals(3, subAttachments.size());
+  }
+}

--- a/source/test/java/com/restfb/types/setter/PostTest.java
+++ b/source/test/java/com/restfb/types/setter/PostTest.java
@@ -6,10 +6,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,7 +25,7 @@ import com.restfb.types.api.SetterGetterTestBase;
 import org.junit.Test;
 
 public class PostTest extends SetterGetterTestBase {
-    
+
     @Test
     public void test() {
 	Post obj = new Post();
@@ -36,7 +36,7 @@ public class PostTest extends SetterGetterTestBase {
 	addIgnoredField("messageTags");
 	testInstance(obj);
     }
-    
+
     @Test
     public void testAction() {
 	Post.Action obj = new Post.Action();
@@ -44,14 +44,14 @@ public class PostTest extends SetterGetterTestBase {
 	addIgnoredField("rawCreatedTime");
 	testInstance(obj);
     }
-    
+
     @Test
     public void testComments() {
 	Post.Comments obj = new Post.Comments();
 	addIgnoredField("summary");
 	testInstance(obj);
     }
-    
+
     @Test
     public void testLikes() {
 	Post.Likes obj = new Post.Likes();
@@ -60,7 +60,7 @@ public class PostTest extends SetterGetterTestBase {
 	addIgnoredField("summary");
 	testInstance(obj);
     }
-    
+
     @Test
     public void testMessageTag() {
 	Post.MessageTag obj = new Post.MessageTag();
@@ -68,7 +68,7 @@ public class PostTest extends SetterGetterTestBase {
 	addIgnoredField("rawCreatedTime");
 	testInstance(obj);
     }
-    
+
     @Test
     public void testPlace() {
 	Post.Place obj = new Post.Place();
@@ -76,7 +76,7 @@ public class PostTest extends SetterGetterTestBase {
 	addIgnoredField("rawCreatedTime");
 	testInstance(obj);
     }
-    
+
     @Test
     public void testPrivacy() {
 	Post.Privacy obj = new Post.Privacy();
@@ -84,7 +84,7 @@ public class PostTest extends SetterGetterTestBase {
 	addIgnoredField("rawCreatedTime");
 	testInstance(obj);
     }
-    
+
     @Test
     public void testProperty() {
 	Post.Property obj = new Post.Property();
@@ -92,7 +92,7 @@ public class PostTest extends SetterGetterTestBase {
 	addIgnoredField("rawCreatedTime");
 	testInstance(obj);
     }
-    
+
     @Test
     public void testShares() {
 	Post.Shares obj = new Post.Shares();
@@ -100,11 +100,17 @@ public class PostTest extends SetterGetterTestBase {
 	addIgnoredField("rawCreatedTime");
 	testInstance(obj);
     }
-    
+
     @Test
     public void testFeedTargeting() {
 	Post.FeedTargeting obj = new Post.FeedTargeting();
 	testInstance(obj);
     }
-	    
+
+    @Test
+    public void testAttachments() {
+	Post.Attachments obj = new Post.Attachments();
+	testInstance(obj);
+    }
+
 }

--- a/source/test/java/com/restfb/types/setter/StoryAttachmentTest.java
+++ b/source/test/java/com/restfb/types/setter/StoryAttachmentTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2010-2015 Norbert Bartels
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.restfb.types.setter;
+
+import com.restfb.types.StoryAttachment;
+import com.restfb.types.api.SetterGetterTestBase;
+import org.junit.Test;
+
+public class StoryAttachmentTest extends SetterGetterTestBase {
+
+  @Test
+  public void testAttachment() {
+    StoryAttachment obj = new StoryAttachment();
+    addIgnoredField("rawCreatedTime");
+    testInstance(obj);
+  }
+
+  @Test
+  public void testAttachments() {
+    StoryAttachment.Attachments obj = new StoryAttachment.Attachments();
+    addIgnoredField("rawCreatedTime");
+    testInstance(obj);
+  }
+
+  @Test
+  public void testImage() {
+    StoryAttachment.Image obj = new StoryAttachment.Image();
+    addIgnoredField("rawCreatedTime");
+    testInstance(obj);
+  }
+
+  @Test
+  public void testMedia() {
+    StoryAttachment.Media obj = new StoryAttachment.Media();
+    addIgnoredField("rawCreatedTime");
+    testInstance(obj);
+  }
+
+  @Test
+  public void testTarget() {
+    StoryAttachment.Target obj = new StoryAttachment.Target();
+    addIgnoredField("rawCreatedTime");
+    testInstance(obj);
+  }
+}

--- a/source/test/resources/json/v2_3/post-attachments.json
+++ b/source/test/resources/json/v2_3/post-attachments.json
@@ -1,0 +1,77 @@
+{
+  "message": "Test",
+  "id": "1234567891234_987654321987654",
+  "created_time": "2015-06-22T12:48:05+0000",
+  "attachments": {
+    "data": [
+      {
+        "media": {
+          "image": {
+            "height": 45,
+            "src": "https://scontent.xx.fbcdn.net/hphotos-xtp1/v/t1.0-9/11329791_921615414561592_7513186513855733255_n.jpg?oh=d428386b208bf56ce09eb5e68436503e&oe=55F21390",
+            "width": 175
+          }
+        },
+        "subattachments": {
+          "data": [
+            {
+              "media": {
+                "image": {
+                  "height": 45,
+                  "src": "https://scontent.xx.fbcdn.net/hphotos-xtp1/v/t1.0-9/11329791_921615414561592_7513186513855733255_n.jpg?oh=d428386b208bf56ce09eb5e68436503e&oe=55F21390",
+                  "width": 175
+                }
+              },
+              "target": {
+                "id": "921615414561592",
+                "url": "https://www.facebook.com/554701551252982/photos/a.921615411228259.1073741830.554701551252982/921615414561592/?type=1"
+              },
+              "title": "22 June 2015 02:37 PM",
+              "type": "photo",
+              "url": "https://www.facebook.com/554701551252982/photos/a.921615411228259.1073741830.554701551252982/921615414561592/?type=1"
+            },
+            {
+              "media": {
+                "image": {
+                  "height": 45,
+                  "src": "https://scontent.xx.fbcdn.net/hphotos-xap1/v/t1.0-9/11206080_921615431228257_6356287105408685109_n.jpg?oh=217fa7fbe2060fce06327d2557e62292&oe=56265C2C",
+                  "width": 175
+                }
+              },
+              "target": {
+                "id": "921615431228257",
+                "url": "https://www.facebook.com/554701551252982/photos/a.921615411228259.1073741830.554701551252982/921615431228257/?type=1"
+              },
+              "title": "22 June 2015 02:37 PM",
+              "type": "photo",
+              "url": "https://www.facebook.com/554701551252982/photos/a.921615411228259.1073741830.554701551252982/921615431228257/?type=1"
+            },
+            {
+              "media": {
+                "image": {
+                  "height": 45,
+                  "src": "https://scontent.xx.fbcdn.net/hphotos-xft1/v/t1.0-9/11350552_921615444561589_600049032119402684_n.jpg?oh=1923e54a74572b18a9ff01b53d128ece&oe=56310D9F",
+                  "width": 175
+                }
+              },
+              "target": {
+                "id": "921615444561589",
+                "url": "https://www.facebook.com/554701551252982/photos/a.921615411228259.1073741830.554701551252982/921615444561589/?type=1"
+              },
+              "title": "22 June 2015 02:37 PM",
+              "type": "photo",
+              "url": "https://www.facebook.com/554701551252982/photos/a.921615411228259.1073741830.554701551252982/921615444561589/?type=1"
+            }
+          ]
+        },
+        "target": {
+          "id": "921615411228259",
+          "url": "https://www.facebook.com/media/set/?set=a.921615411228259.1073741830.554701551252982&type=3"
+        },
+        "title": "22 June 2015 02:37 PM",
+        "type": "new_album",
+        "url": "https://www.facebook.com/media/set/?set=a.921615411228259.1073741830.554701551252982&type=3"
+      }
+    ]
+  }
+}

--- a/source/test/resources/json/v2_3/story-attachment.json
+++ b/source/test/resources/json/v2_3/story-attachment.json
@@ -1,0 +1,68 @@
+{
+  "media": {
+    "image": {
+      "height": 45,
+      "src": "https://scontent.xx.fbcdn.net/hphotos-xtp1/v/t1.0-9/11329791_921615414561592_7513186513855733255_n.jpg?oh=d428386b208bf56ce09eb5e68436503e&oe=55F21390",
+      "width": 175
+    }
+  },
+  "subattachments": {
+    "data": [
+      {
+        "media": {
+          "image": {
+            "height": 45,
+            "src": "https://scontent.xx.fbcdn.net/hphotos-xtp1/v/t1.0-9/11329791_921615414561592_7513186513855733255_n.jpg?oh=d428386b208bf56ce09eb5e68436503e&oe=55F21390",
+            "width": 175
+          }
+        },
+        "target": {
+          "id": "921615414561592",
+          "url": "https://www.facebook.com/554701551252982/photos/a.921615411228259.1073741830.554701551252982/921615414561592/?type=1"
+        },
+        "title": "22 June 2015 02:37 PM",
+        "type": "photo",
+        "url": "https://www.facebook.com/554701551252982/photos/a.921615411228259.1073741830.554701551252982/921615414561592/?type=1"
+      },
+      {
+        "media": {
+          "image": {
+            "height": 45,
+            "src": "https://scontent.xx.fbcdn.net/hphotos-xap1/v/t1.0-9/11206080_921615431228257_6356287105408685109_n.jpg?oh=217fa7fbe2060fce06327d2557e62292&oe=56265C2C",
+            "width": 175
+          }
+        },
+        "target": {
+          "id": "921615431228257",
+          "url": "https://www.facebook.com/554701551252982/photos/a.921615411228259.1073741830.554701551252982/921615431228257/?type=1"
+        },
+        "title": "22 June 2015 02:37 PM",
+        "type": "photo",
+        "url": "https://www.facebook.com/554701551252982/photos/a.921615411228259.1073741830.554701551252982/921615431228257/?type=1"
+      },
+      {
+        "media": {
+          "image": {
+            "height": 45,
+            "src": "https://scontent.xx.fbcdn.net/hphotos-xft1/v/t1.0-9/11350552_921615444561589_600049032119402684_n.jpg?oh=1923e54a74572b18a9ff01b53d128ece&oe=56310D9F",
+            "width": 175
+          }
+        },
+        "target": {
+          "id": "921615444561589",
+          "url": "https://www.facebook.com/554701551252982/photos/a.921615411228259.1073741830.554701551252982/921615444561589/?type=1"
+        },
+        "title": "22 June 2015 02:37 PM",
+        "type": "photo",
+        "url": "https://www.facebook.com/554701551252982/photos/a.921615411228259.1073741830.554701551252982/921615444561589/?type=1"
+      }
+    ]
+  },
+  "target": {
+    "id": "921615411228259",
+    "url": "https://www.facebook.com/media/set/?set=a.921615411228259.1073741830.554701551252982&type=3"
+  },
+  "title": "22 June 2015 02:37 PM",
+  "type": "new_album",
+  "url": "https://www.facebook.com/media/set/?set=a.921615411228259.1073741830.554701551252982&type=3"
+}


### PR DESCRIPTION
Hi,

I added StoryAttachment object which is the type for attachments in [Post and Comment Object](https://developers.facebook.com/docs/graph-api/reference/v2.3/story_attachment). I didn't rework Comment object cause of incompatibility issues with previous version, but I think it could be great to do that. Is it ok for you ?

Please let me know if something is missing in my PR.
Regards