### PR TITLE
Allow blank URLs in BatchRequest for object updates

### DIFF
--- a/source/library/com/restfb/batch/BatchRequest.java
+++ b/source/library/com/restfb/batch/BatchRequest.java
@@ -94,11 +94,11 @@ public class BatchRequest {
    *          To make sure FB returns JSON in the event that this request completes successfully, set this to
    *          {@code false}.
    * @throws IllegalArgumentException
-   *           If {@code relativeUrl} is {@code null} or blank.
+   *           If {@code relativeUrl} is {@code null}.
    */
   protected BatchRequest(String relativeUrl, List<Parameter> parameters, String method, List<BatchHeader> headers,
       List<Parameter> bodyParameters, String attachedFiles, String dependsOn, String name, boolean omitResponseOnSuccess) {
-    if (isBlank(relativeUrl)) {
+    if (relativeUrl == null) {
       throw new IllegalArgumentException("The 'relativeUrl' parameter is required.");
     }
 


### PR DESCRIPTION
Facebook allows object updates by making POST requests to a blank edge
ID and specifying scrape=true and an id (either an object instance id
or a URL) as parameters.  BatchRequest doesn't currently allow
relativeUrl to be blank.  Facebook doesn't support either "." or "./"
as relativeUrls.  "?" and "/" are workarounds, but they're confusing,
and they don't mirror Facebook's documentation.

See https://developers.facebook.com/docs/sharing/opengraph/using-objects#update