### PR TITLE
Code quality fix - Collection.isEmpty() should be used to test for emptiness of collections

### DIFF
--- a/source/library/com/restfb/DefaultFacebookClient.java
+++ b/source/library/com/restfb/DefaultFacebookClient.java
@@ -854,7 +854,7 @@ public class DefaultFacebookClient extends BaseFacebookClient implements Faceboo
     }
 
     final String fullEndpoint =
-        createEndpointForApiCall(endpoint, binaryAttachments != null && binaryAttachments.size() > 0);
+        createEndpointForApiCall(endpoint, binaryAttachments != null && !binaryAttachments.isEmpty());
     final String parameterString = toParameterString(parameters);
 
     return makeRequestAndProcessResponse(new Requestor() {

--- a/source/library/com/restfb/DefaultJsonMapper.java
+++ b/source/library/com/restfb/DefaultJsonMapper.java
@@ -528,7 +528,7 @@ public class DefaultJsonMapper implements JsonMapper {
     // it has is a non-null value and the other duplicate values are null, use
     // the non-null field.
     Set<String> facebookFieldNamesWithMultipleMappings = facebookFieldNamesWithMultipleMappings(fieldsWithAnnotation);
-    if (facebookFieldNamesWithMultipleMappings.size() > 0 && logger.isLoggable(FINE)) {
+    if (!facebookFieldNamesWithMultipleMappings.isEmpty() && logger.isLoggable(FINE)) {
       logger.fine("Unable to convert to JSON because multiple @" + Facebook.class.getSimpleName()
           + " annotations for the same name are present: " + facebookFieldNamesWithMultipleMappings);
     }

--- a/source/test/java/com/restfb/JsonMapperToJavaTest.java
+++ b/source/test/java/com/restfb/JsonMapperToJavaTest.java
@@ -58,7 +58,7 @@ public class JsonMapperToJavaTest extends AbstractJsonMapperTests {
   @Test
   public void emptyList() {
     List<Object> objects = createJsonMapper().toJavaList("[]", Object.class);
-    assertTrue(objects.size() == 0);
+    assertTrue(objects.isEmpty());
   }
 
   /**
@@ -173,7 +173,7 @@ public class JsonMapperToJavaTest extends AbstractJsonMapperTests {
 
     // Make sure the weird Facebook "empty object means empty list" workaround
     // works
-    assertTrue(usersWithAffiliations.get(2).affiliations.size() == 0);
+    assertTrue(usersWithAffiliations.get(2).affiliations.isEmpty());
   }
 
   /**

--- a/source/test/java/com/restfb/SpecialCommentHandlingTest.java
+++ b/source/test/java/com/restfb/SpecialCommentHandlingTest.java
@@ -42,7 +42,7 @@ public class SpecialCommentHandlingTest extends AbstractJsonMapperTests {
   public void emptyArrayTest() {
     Post post = createJsonMapper().toJavaObject(jsonFromClasspath("post-with-empty-comments"), Post.class);
     assertTrue(post.getComments().getTotalCount() == 0);
-    assertTrue(post.getComments().getData().size() == 0);
+    assertTrue(post.getComments().getData().isEmpty());
   }
 
   /**

--- a/source/test/java/com/restfb/integration/FetchConnectionPageITCase.java
+++ b/source/test/java/com/restfb/integration/FetchConnectionPageITCase.java
@@ -21,7 +21,7 @@
  */
 package com.restfb.integration;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 import com.restfb.Connection;
@@ -39,10 +39,10 @@ public class FetchConnectionPageITCase extends RestFbIntegrationTestBase {
     DefaultFacebookClient client =
         new DefaultFacebookClient(getTestSettings().getUserAccessToken(), Version.VERSION_2_1);
     Connection<Post> connection = client.fetchConnection("/cocacola/feed", Post.class);
-    assertTrue(connection.getData().size() > 0);
+    assertFalse(connection.getData().isEmpty());
     if (connection.hasNext()) {
       Connection<Post> connection2 = client.fetchConnectionPage(connection.getNextPageUrl(), Post.class);
-      assertTrue(connection2.getData().size() > 0);
+      assertFalse(connection2.getData().isEmpty());
     } else {
       fail("Page has no second connection");
     }

--- a/source/test/java/com/restfb/integration/FetchInboxITCase.java
+++ b/source/test/java/com/restfb/integration/FetchInboxITCase.java
@@ -23,6 +23,7 @@ package com.restfb.integration;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import com.restfb.Connection;
 import com.restfb.DefaultFacebookClient;
@@ -44,8 +45,8 @@ public class FetchInboxITCase extends RestFbIntegrationTestBase {
     assertNotNull(connection.getData());
 
     List<com.restfb.types.Thread> threadList = connection.getData();
-    assertTrue(threadList.size() > 0);
-    assertTrue(threadList.get(0).getComments().size() > 0);
+    assertFalse(threadList.isEmpty());
+    assertFalse(threadList.get(0).getComments().isEmpty());
 
     for (com.restfb.types.Thread thread : threadList) {
       assertNotNull(thread.getId());

--- a/source/test/java/com/restfb/integration/experimental/FetchGroupMemberITCase.java
+++ b/source/test/java/com/restfb/integration/experimental/FetchGroupMemberITCase.java
@@ -22,7 +22,7 @@
 package com.restfb.integration.experimental;
 
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import com.restfb.DefaultFacebookClient;
 import com.restfb.Version;
@@ -43,7 +43,7 @@ public class FetchGroupMemberITCase extends RestFbIntegrationTestBase {
     Facebook fb = new Facebook(client);
     List<NamedFacebookType> memberList = fb.groups().memberList(getTestSettings().getGroupId());
     assertNotNull(memberList);
-    assertTrue(memberList.size() > 0);
+    assertFalse(memberList.isEmpty());
   }
 
 }

--- a/source/test/java/com/restfb/integration/experimental/UserApiITCase.java
+++ b/source/test/java/com/restfb/integration/experimental/UserApiITCase.java
@@ -52,7 +52,7 @@ public class UserApiITCase extends RestFbIntegrationTestBase {
   public void fetchAllAccounts() {
     List<Account> accList = fb.users().getAccounts();
     assertNotNull(accList);
-    assertTrue(accList.size() > 0);
+    assertFalse(accList.isEmpty());
   }
 
   @Test

--- a/source/test/java/com/restfb/types/api/ApiCheckTest.java
+++ b/source/test/java/com/restfb/types/api/ApiCheckTest.java
@@ -47,7 +47,7 @@ public class ApiCheckTest extends BaseTestCheck {
         String[] methods = value.split(",");
         expectedMethods = new HashSet<String>(Arrays.asList(methods));
       }
-      if (expectedMethods.size() > 0) {
+      if (!expectedMethods.isEmpty()) {
         for (Iterator<String> expIterator = expectedMethods.iterator(); expIterator.hasNext();) {
           String expMethod = expIterator.next();
           assertTrue(key + " method not found " + expMethod, currentMethods.contains(expMethod));

--- a/source/test/java/com/restfb/types/api/BaseTestCheck.java
+++ b/source/test/java/com/restfb/types/api/BaseTestCheck.java
@@ -43,7 +43,7 @@ public class BaseTestCheck {
       result += methodName + ",";
     }
 
-    if (methodList.size() > 0) {
+    if (!methodList.isEmpty()) {
       return result.substring(0, result.length() - 1);
     } else {
       return result;

--- a/source/test/java/com/restfb/util/UrlUtilsTest.java
+++ b/source/test/java/com/restfb/util/UrlUtilsTest.java
@@ -36,17 +36,17 @@ import org.junit.Test;
 public class UrlUtilsTest {
   @Test
   public void queryString() {
-    assertTrue(extractParametersFromQueryString(null).size() == 0);
-    assertTrue(extractParametersFromQueryString("").size() == 0);
+    assertTrue(extractParametersFromQueryString(null).isEmpty());
+    assertTrue(extractParametersFromQueryString("").isEmpty());
     assertTrue(extractParametersFromQueryString("access_token=123").size() == 1);
     assertTrue(extractParametersFromQueryString("?access_token=123").size() == 1);
   }
 
   @Test
   public void urlParameters() {
-    assertTrue(extractParametersFromUrl(null).size() == 0);
-    assertTrue(extractParametersFromUrl("").size() == 0);
-    assertTrue(extractParametersFromUrl("access_token=123").size() == 0);
+    assertTrue(extractParametersFromUrl(null).isEmpty());
+    assertTrue(extractParametersFromUrl("").isEmpty());
+    assertTrue(extractParametersFromUrl("access_token=123").isEmpty());
     assertTrue(extractParametersFromUrl("?access_token=123").size() == 1);
     assertTrue(extractParametersFromUrl("http://whatever?access_token=123").size() == 1);
   }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule: 
squid:S1155 - Collection.isEmpty() should be used to test for emptiness of collections

You can find more information about the issue here: dev.eclipse.org/sonar/rules/show/squid:S1155

Please let me know if you have any questions.

Faisal