### PR TITLE
Code quality fix - @Override annotation should be used on any method overriding

### DIFF
--- a/source/example/com/restfb/example/LegacyExample.java
+++ b/source/example/com/restfb/example/LegacyExample.java
@@ -143,6 +143,7 @@ public class LegacyExample extends Example {
     @Facebook
     List<Affiliation> affiliations;
 
+    @Override
     public String toString() {
       return format("Name: %s\nProfile Image URL: %s\nAffiliations: %s", name, pictureUrl, affiliations);
     }
@@ -155,6 +156,7 @@ public class LegacyExample extends Example {
     @Facebook
     String type;
 
+    @Override
     public String toString() {
       return format("%s (%s)", name, type);
     }

--- a/source/library/com/restfb/exception/generator/DefaultFacebookExceptionGenerator.java
+++ b/source/library/com/restfb/exception/generator/DefaultFacebookExceptionGenerator.java
@@ -167,6 +167,7 @@ public class DefaultFacebookExceptionGenerator extends DefaultLegacyFacebookExce
      * @see com.restfb.exception.FacebookExceptionMapper#exceptionForTypeAndMessage(Integer, Integer, Integer, String,
      *      String, String, String, JsonObject)
      */
+    @Override
     public FacebookException exceptionForTypeAndMessage(Integer errorCode, Integer errorSubcode, Integer httpStatusCode,
         String type, String message, String errorUserTitle, String errorUserMessage, JsonObject rawError) {
       if ("OAuthException".equals(type) || "OAuthAccessTokenException".equals(type)) {

--- a/source/test/java/com/restfb/AbstractJsonMapperTests.java
+++ b/source/test/java/com/restfb/AbstractJsonMapperTests.java
@@ -39,6 +39,7 @@ public abstract class AbstractJsonMapperTests {
 
   protected JsonMapper createErrorSwallowingJsonMapper() {
     return new DefaultJsonMapper(new JsonMappingErrorHandler() {
+      @Override
       public boolean handleMappingError(String unmappableJson, Class<?> targetType, Exception e) {
         getLogger("ErrorSwallowingJsonMapper").info(format(
           "Ignored failed mapping to %s. " + "Bad JSON was '%s' and exception was %s", targetType, unmappableJson, e));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule: 
squid:S1161 - @Override annotation should be used on any method overriding

You can find more information about the issue here: 
http://dev.eclipse.org/sonar/rules/show/squid:S1161

Please let me know if you have any questions.

Faisal