### PR TITLE
Handled missing rating, is_draft, language fields in PageRating

### DIFF
--- a/source/library/com/restfb/types/PageRating.java
+++ b/source/library/com/restfb/types/PageRating.java
@@ -38,6 +38,7 @@ import lombok.Setter;
  * type</a>.
  * 
  * @author Anand Hemmige
+ * @author Venil Noronha
  * @since 1.6.16
  */
 public class PageRating extends FacebookType {
@@ -133,14 +134,17 @@ public class PageRating extends FacebookType {
   @JsonMappingCompleted
   void fillAddititonalValues(JsonMapper mapper) {
     if (data != null) {
-      JsonObject rating = data.getJsonObject("rating");
-      if (rating != null) {
+      if (data.has("rating")) {
+        JsonObject rating = data.getJsonObject("rating");
         ratingValue = rating.getDouble("value");
         ratingScale = rating.getLong("scale");
       }
-
-      isDraft = data.getBoolean("is_draft");
-      language = data.getString("language");
+      if (data.has("is_draft")) {
+        isDraft = data.getBoolean("is_draft");
+      }
+      if (data.has("language")) {
+        language = data.getString("language");
+      }
       place = mapper.toJavaObject(data.get("generic_place").toString(), Place.class);
     }
   }


### PR DESCRIPTION
This should fix #409. Please review and pull.

Thanks,
Venil Noronha