### PR TITLE
Adding xmpp_login extended page permission.

### DIFF
--- a/source/library/com/restfb/scope/ExtendedPermissions.java
+++ b/source/library/com/restfb/scope/ExtendedPermissions.java
@@ -221,6 +221,19 @@ public enum ExtendedPermissions implements FacebookPermissions {
   READ_INSIGHTS("read_insights"), //
 
   /**
+   * Facebook has not yet officially documented this permission, but it is necessary for certain integrations
+   * with the new Messenger Platform.
+   *
+   * <p>
+   * <strong>Review</strong>
+   *
+   * <p>
+   * Your app will need to be approved and whitelisted by Facebook to use of this permission.
+   * @since Graph API 2.5
+   */
+  XMPP_LOGIN("xmpp_login"), //
+
+  /**
    * Provides the ability to read the messages in a person's Facebook Inbox through the inbox edge and the thread node.
    *
    * <p>
@@ -258,7 +271,7 @@ public enum ExtendedPermissions implements FacebookPermissions {
    * If your app requests this permission Facebook will have to review how your app uses it.
    *
    * <p>
-   * 
+   *
    * @deprecated Not usable since Graph API 2.4. If you use the Graph API before 2.4 ignore the deprecation warning
    */
   @Deprecated READ_STREAM("read_stream"), //


### PR DESCRIPTION
Facebook has not yet officially documented this permission, but it is necessary for certain integrations
with the new Messenger Platform (announced this week at F8).