### PR TITLE
Per documentation here: https://developers.facebook.com/docs/messenge…

### DIFF
--- a/source/library/com/restfb/types/webhook/messaging/MessageItem.java
+++ b/source/library/com/restfb/types/webhook/messaging/MessageItem.java
@@ -48,6 +48,11 @@ public class MessageItem implements InnerMessagingItem {
 
   @Getter
   @Setter
+  @Facebook("is_echo")
+  private boolean isEcho;
+
+  @Getter
+  @Setter
   @Facebook
   private List<MessagingAttachment> attachments = new ArrayList<MessagingAttachment>();
 }


### PR DESCRIPTION
…r-platform/send-receive-api-updates#request

is_echo flag will be added to "message" attribute. Added to codebase.

Note that to receive these echoes, your web hook must be subscribed to the "message_echoes" event (this event is already accessible via the Facebook Developer Dashboard, and these events can already be seen, the documentation simply has not yet been merged).