### PR TITLE
Message object should contain a "metadata" field (this is already imp…

### DIFF
--- a/source/library/com/restfb/types/send/Message.java
+++ b/source/library/com/restfb/types/send/Message.java
@@ -22,11 +22,16 @@
 package com.restfb.types.send;
 
 import com.restfb.Facebook;
+import lombok.Setter;
 
 public class Message {
 
   @Facebook
   private String text;
+
+  @Setter
+  @Facebook
+  private String metadata;
 
   @Facebook
   private MessageAttachment attachment;

--- a/source/library/com/restfb/types/send/QuickReply.java
+++ b/source/library/com/restfb/types/send/QuickReply.java
@@ -22,39 +22,20 @@
 package com.restfb.types.send;
 
 import com.restfb.Facebook;
-import lombok.Setter;
 
-import java.util.ArrayList;
-import java.util.List;
+public class QuickReply {
+    @Facebook
+    private String contentType;
 
-public class Message {
+    @Facebook
+    private String title;
 
-  @Facebook
-  private String text;
+    @Facebook
+    private String payload;
 
-  @Facebook
-  private List<QuickReply> quickReplies;
-
-  @Setter
-  @Facebook
-  private String metadata;
-
-  @Facebook
-  private MessageAttachment attachment;
-
-  public Message(String text) {
-    this.text = text;
-  }
-
-  public Message(MessageAttachment attachment) {
-    this.attachment = attachment;
-  }
-
-  public boolean addQuickReply(QuickReply quickReply) {
-    if (quickReplies == null) {
-      quickReplies = new ArrayList<QuickReply>();
+    public QuickReply(String contentType, String title, String payload) {
+        this.contentType = contentType;
+        this.title = title;
+        this.payload = payload;
     }
-
-    return quickReplies.add(quickReply);
-  }
 }

--- a/source/test/java/com/restfb/types/SendApiTest.java
+++ b/source/test/java/com/restfb/types/SendApiTest.java
@@ -219,4 +219,21 @@ public class SendApiTest extends AbstractJsonMapperTests {
             "{\"attachment\":{\"payload\":{\"checkin_url\":\"http://www.google.com/checkin\",\"intro_message\":\"Intro Message\",\"template_type\":\"airline_checkin\",\"locale\":\"en_US\",\"pnr_number\":\"ABCDEF\"},\"type\":\"template\"}}",
             recipientJsonString, false);
   }
+
+  @Test
+  public void messageWithQuickRepliesAndMetadata() throws JSONException {
+    QuickReply quickReply1 = new QuickReply("text", "title 1", "payload 1");
+    QuickReply quickReply2 = new QuickReply("text", "title 2", "payload 2");
+    Message message = new Message("message text");
+    message.setMetadata("metadata payload");
+    message.addQuickReply(quickReply1);
+    message.addQuickReply(quickReply2);
+
+    DefaultJsonMapper mapper = new DefaultJsonMapper();
+    String messageJsonString = mapper.toJson(message, true);
+    System.out.println(messageJsonString);
+
+    JSONAssert.assertEquals("{\"quickReplies\":[{\"payload\":\"payload 1\",\"title\":\"title 1\",\"contentType\":\"text\"},{\"payload\":\"payload 2\",\"title\":\"title 2\",\"contentType\":\"text\"}],\"metadata\":\"metadata payload\",\"text\":\"message text\"}",
+            messageJsonString, false);
+  }
 }


### PR DESCRIPTION
…lemented on the receiving end, but it was missed on the sending side): https://developers.facebook.com/docs/messenger-platform/send-api-reference#request