### PR TITLE
Removed 'product' from com.restfb.types.Payment

### DIFF
--- a/source/library/com/restfb/types/Payment.java
+++ b/source/library/com/restfb/types/Payment.java
@@ -49,14 +49,6 @@ public class Payment extends FacebookType {
   private User user;
 
   /**
-   * The URL of the {@code og:product} object ordered
-   */
-  @Getter
-  @Setter
-  @Facebook
-  private String product;
-
-  /**
    * The quantity of the product contained in the order
    */
   @Getter


### PR DESCRIPTION
Removed 'product' from com.restfb.types.Payment because this field does
not exists. For more information, check
https://developers.facebook.com/bugs/1319810038048999/ .
Fixes #527 