### PR TITLE
Added ChangeValue type FEED_REACTION_ADD

### DIFF
--- a/source/library/com/restfb/types/webhook/ChangeValueFactory.java
+++ b/source/library/com/restfb/types/webhook/ChangeValueFactory.java
@@ -100,6 +100,7 @@ public class ChangeValueFactory {
     FEED_POST_HIDE(FeedPostValue.class), //
     FEED_POST_REMOVE(FeedPostValue.class), //
     FEED_POST_UNHIDE(FeedPostValue.class), //
+    FEED_REACTION_ADD(FeedReactionValue.class),
     FEED_SHARE_ADD(FeedShareValue.class), //
     FEED_SHARE_EDITED(FeedShareValue.class), //
     FEED_SHARE_HIDE(FeedShareValue.class), //

--- a/source/library/com/restfb/types/webhook/FeedReactionValue.java
+++ b/source/library/com/restfb/types/webhook/FeedReactionValue.java
@@ -1,0 +1,18 @@
+package com.restfb.types.webhook;
+
+import com.restfb.Facebook;
+import com.restfb.types.webhook.base.AbstractFeedPostValue;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Change value describing a reaction to a post.
+ */
+public class FeedReactionValue extends AbstractFeedPostValue {
+
+  @Getter
+  @Setter
+  @Facebook("parent_id")
+  private String parentId;
+
+}

--- a/source/test/java/com/restfb/types/WebhookTest.java
+++ b/source/test/java/com/restfb/types/WebhookTest.java
@@ -50,6 +50,7 @@ public class WebhookTest extends AbstractJsonMapperTests {
   private static final String ITEM_LIKE = "like";
   private static final String ITEM_PHOTO = "photo";
   private static final String ITEM_POST = "post";
+  private static final String ITEM_REACTION = "reaction";
   private static final String ITEM_SHARE = "share";
   private static final String ITEM_STATUS = "status";
   private static final String ITEM_RATING = "rating";
@@ -172,6 +173,15 @@ public class WebhookTest extends AbstractJsonMapperTests {
     assertEquals("1234567890321_7293787835232", value.getPostId());
     assertEquals("8423678347823", value.getSenderId());
     assertEquals("Let's check this", value.getMessage());
+  }
+
+  @Test
+  public void feedReactionAdd() {
+    FeedReactionValue value =
+        openAndCheckFeedPostBasics("feed-reaction-add", FeedReactionValue.class, ITEM_REACTION, ChangeValue.Verb.ADD);
+    assertEquals("1234567890321_98735342324352", value.getPostId());
+    assertEquals("1234567890321_901097836652708", value.getParentId());
+    assertEquals("1234567890321", value.getSenderId());
   }
 
   @Test

--- a/source/test/resources/json/webhooks/feed-reaction-add.json
+++ b/source/test/resources/json/webhooks/feed-reaction-add.json
@@ -1,0 +1,24 @@
+{
+	"object": "page",
+	"entry": [
+		{
+			"id": "1234567890321",
+			"time": 1449135003,
+			"changes": [
+				{
+					"field": "feed",
+					"value": {
+						"created_time": 1475578854,
+						"item": "reaction",
+						"post_id": "1234567890321_98735342324352",
+						"parent_id": "1234567890321_901097836652708",
+						"verb": "add",
+						"sender_id": 1234567890321
+					}
+				}
+			]
+		}
+	]
+}
+
+


### PR DESCRIPTION
I created this after receiving the following warning in my logs:
```
2016-10-04 13:01:00,307 WARNING [com.restfb.types.webhook.ChangeValueFactory] (EJB default - 7) undefined change 
value detected: FEED_REACTION_ADD
2016-10-04 13:01:00,307 WARNING [com.restfb.types.webhook.ChangeValueFactory] (EJB default - 7) please provide this information to the restfb team: {"created_time":1475578854,"item":"reaction","post_id":"...","parent_id":"...","verb":"add","sender_id":..}
```

(IDs omitted for privacy reasons)