### PR TITLE
add support for interests in post.feed_targeting

### DIFF
--- a/source/library/com/restfb/types/Post.java
+++ b/source/library/com/restfb/types/Post.java
@@ -21,24 +21,23 @@
  */
 package com.restfb.types;
 
-import static com.restfb.json.JsonObject.getNames;
-import static com.restfb.util.DateUtils.toDateFromLongFormat;
-import static java.util.Collections.unmodifiableList;
-
 import com.restfb.Facebook;
 import com.restfb.JsonMapper;
 import com.restfb.JsonMapper.JsonMappingCompleted;
 import com.restfb.exception.FacebookJsonMappingException;
 import com.restfb.json.JsonObject;
 import com.restfb.types.Checkin.Place.Location;
+import com.restfb.util.DateUtils;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import com.restfb.util.DateUtils;
-import lombok.Getter;
-import lombok.Setter;
+import static com.restfb.json.JsonObject.getNames;
+import static com.restfb.util.DateUtils.toDateFromLongFormat;
+import static java.util.Collections.unmodifiableList;
 
 /**
  * Represents the <a href="https://developers.facebook.com/docs/graph-api/reference/post/">Post Graph API type</a>.
@@ -893,6 +892,9 @@ public class Post extends NamedFacebookType {
     @Facebook("interested_in")
     private List<Integer> interestedIn = new ArrayList<Integer>();
 
+    @Facebook
+    private List<String> interests = new ArrayList<String>();
+
     @Facebook("relationship_statuses")
     private List<Integer> relationshipStatuses = new ArrayList<Integer>();
 
@@ -1032,6 +1034,24 @@ public class Post extends NamedFacebookType {
     public boolean removeInterestedIn(Integer interest) {
       return interestedIn.remove(interest);
     }
+
+    /**
+     * Indicates targeting based on the 'interests' field of the user profile.
+     *
+     * @return list of 'interests' types
+     */
+    public List<String> getInterests() {
+      return unmodifiableList(interests);
+    }
+
+    public boolean addInterests(String interest) {
+      return interests.add(interest);
+    }
+
+    public boolean removeInterests(String interest) {
+      return interests.remove(interest);
+    }
+
 
     /**
      * Array of integers for targeting based on relationship status.

--- a/source/test/java/com/restfb/types/PostTest.java
+++ b/source/test/java/com/restfb/types/PostTest.java
@@ -21,13 +21,16 @@
  */
 package com.restfb.types;
 
-import static org.junit.Assert.*;
-
 import com.restfb.AbstractJsonMapperTests;
-
 import org.junit.Test;
 
 import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class PostTest extends AbstractJsonMapperTests {
 
@@ -293,5 +296,31 @@ public class PostTest extends AbstractJsonMapperTests {
     assertNotNull(examplePost.getFeedTargeting().getRelevantUntilTs());
     Date ts = examplePost.getFeedTargeting().getRelevantUntilTs();
     assertEquals(1457620560000L, ts.getTime());
+  }
+
+  @Test
+  public void checkV2_5_feedTargetingWithRegions() {
+    Post examplePost = createJsonMapper().toJavaObject(jsonFromClasspath("v2_5/post-with-feedtargeting-regions"), Post.class);
+    assertNotNull(examplePost);
+    assertNotNull(examplePost.getFeedTargeting());
+    assertNotNull(examplePost.getFeedTargeting().getGeoLocations());
+    assertNotNull(examplePost.getFeedTargeting().getGeoLocations().getRegions());
+    assertFalse(examplePost.getFeedTargeting().getGeoLocations().getRegions().isEmpty());
+
+    assertNotNull(examplePost.getFeedTargeting().getInterests());
+    assertFalse(examplePost.getFeedTargeting().getInterests().isEmpty());
+  }
+
+  @Test
+  public void checkV2_8_feedTargetingWithRegions() {
+    Post examplePost = createJsonMapper().toJavaObject(jsonFromClasspath("v2_8/post-with-feedtargeting-regions"), Post.class);
+    assertNotNull(examplePost);
+    assertNotNull(examplePost.getFeedTargeting());
+    assertNotNull(examplePost.getFeedTargeting().getGeoLocations());
+    assertNotNull(examplePost.getFeedTargeting().getGeoLocations().getRegions());
+    assertFalse(examplePost.getFeedTargeting().getGeoLocations().getRegions().isEmpty());
+
+    assertNotNull(examplePost.getFeedTargeting().getInterests());
+    assertFalse(examplePost.getFeedTargeting().getInterests().isEmpty());
   }
 }

--- a/source/test/resources/json/v2_5/post-with-feedtargeting-regions.json
+++ b/source/test/resources/json/v2_5/post-with-feedtargeting-regions.json
@@ -1,0 +1,54 @@
+{
+  "targeting": {
+    "age_min": 21,
+    "age_max": 65,
+    "locales": [
+      23,
+      88
+    ],
+    "geo_locations": {
+      "countries": [
+        "CA"
+      ],
+      "regions": {
+        "0": {
+          "key": "3886"
+        }
+      },
+      "cities": [
+        {
+          "key": "2468631"
+        }
+      ]
+    }
+  },
+  "feed_targeting": {
+    "age_min": 21,
+    "age_max": 65,
+    "locales": [
+      23
+    ],
+    "genders": [
+      1
+    ],
+    "interests": [
+      "6003012461997"
+    ],
+    "geo_locations": {
+      "countries": [
+        "CA"
+      ],
+      "regions": {
+        "0": {
+          "key": "3886"
+        }
+      },
+      "cities": [
+        {
+          "key": "2468631"
+        }
+      ]
+    }
+  },
+  "id": "703438126457284_868981499902945"
+}

--- a/source/test/resources/json/v2_8/post-with-feedtargeting-regions.json
+++ b/source/test/resources/json/v2_8/post-with-feedtargeting-regions.json
@@ -1,0 +1,54 @@
+{
+  "targeting": {
+    "age_min": 21,
+    "age_max": 65,
+    "locales": [
+      23,
+      88
+    ],
+    "geo_locations": {
+      "countries": [
+        "CA"
+      ],
+      "regions": [
+        {
+          "key": "3886"
+        }
+      ],
+      "cities": [
+        {
+          "key": "2468631"
+        }
+      ]
+    }
+  },
+  "feed_targeting": {
+    "age_min": 21,
+    "age_max": 65,
+    "locales": [
+      23
+    ],
+    "genders": [
+      1
+    ],
+    "interests": [
+      "6003012461997"
+    ],
+    "geo_locations": {
+      "countries": [
+        "CA"
+      ],
+      "regions": [
+        {
+          "key": "3886"
+        }
+      ],
+      "cities": [
+        {
+          "key": "2468631"
+        }
+      ]
+    }
+  },
+  "id": "703438126457284_868981499902945"
+}


### PR DESCRIPTION
Only the v2.8 test that I added passes.  I added the v2.5 test to demonstrate that the change proposed in issue #589 would break deserialization for those requesting non v2.8 versions of feed_targeting and targeting fields. 

This really feels like a bug on facebook's side since the datatype returned is inconsistent depending on the version being used, so I'm not sure what your policy is on working around that.  I just wanted to add the test to demonstrate the issue and start this discussion. 