### PR TITLE
demonstration of targeting data not deserialized

### DIFF
--- a/source/test/java/com/restfb/types/PostTest.java
+++ b/source/test/java/com/restfb/types/PostTest.java
@@ -21,13 +21,16 @@
  */
 package com.restfb.types;
 
-import static org.junit.Assert.*;
-
 import com.restfb.AbstractJsonMapperTests;
-
 import org.junit.Test;
 
 import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class PostTest extends AbstractJsonMapperTests {
 
@@ -308,29 +311,36 @@ public class PostTest extends AbstractJsonMapperTests {
 
   @Test
   public void checkV2_5_feedTargetingWithRegions() {
-    Post examplePost =
-        createJsonMapper().toJavaObject(jsonFromClasspath("v2_5/post-with-feedtargeting-regions"), Post.class);
-    assertNotNull(examplePost);
-    assertNotNull(examplePost.getFeedTargeting());
-    assertNotNull(examplePost.getFeedTargeting().getGeoLocations());
-    assertNotNull(examplePost.getFeedTargeting().getGeoLocations().getRegions());
-    assertFalse(examplePost.getFeedTargeting().getGeoLocations().getRegions().isEmpty());
-
-    assertNotNull(examplePost.getFeedTargeting().getInterests());
-    assertFalse(examplePost.getFeedTargeting().getInterests().isEmpty());
+    verifyFeedTargeting("v2_5/post-with-feedtargeting-regions");
   }
 
   @Test
   public void checkV2_8_feedTargetingWithRegions() {
-    Post examplePost =
-        createJsonMapper().toJavaObject(jsonFromClasspath("v2_8/post-with-feedtargeting-regions"), Post.class);
+    verifyFeedTargeting("v2_8/post-with-feedtargeting-regions");
+  }
+
+  private void verifyFeedTargeting(String exampleFile) {
+    Post examplePost = createJsonMapper().toJavaObject(jsonFromClasspath(exampleFile), Post.class);
     assertNotNull(examplePost);
     assertNotNull(examplePost.getFeedTargeting());
+    assertEquals(Integer.valueOf(21), examplePost.getFeedTargeting().getAgeMin());
+    assertEquals(Integer.valueOf(65), examplePost.getFeedTargeting().getAgeMax());
+    assertNotNull(examplePost.getFeedTargeting().getGenders());
+    assertFalse(examplePost.getFeedTargeting().getGenders().isEmpty());
+    assertEquals(Integer.valueOf(1), examplePost.getFeedTargeting().getGenders().get(0));
     assertNotNull(examplePost.getFeedTargeting().getGeoLocations());
     assertNotNull(examplePost.getFeedTargeting().getGeoLocations().getRegions());
     assertFalse(examplePost.getFeedTargeting().getGeoLocations().getRegions().isEmpty());
+    assertEquals("3886", examplePost.getFeedTargeting().getGeoLocations().getRegions().get(0).getName());
+    assertEquals("2468631", examplePost.getFeedTargeting().getGeoLocations().getCities().get(0).getName());
+    assertEquals("CA", examplePost.getFeedTargeting().getGeoLocations().getCountries().get(0));
 
     assertNotNull(examplePost.getFeedTargeting().getInterests());
     assertFalse(examplePost.getFeedTargeting().getInterests().isEmpty());
+    assertEquals("6003012461997", examplePost.getFeedTargeting().getInterests().get(0));
+
+    assertNotNull(examplePost.getFeedTargeting().getLocales());
+    assertFalse(examplePost.getFeedTargeting().getLocales().isEmpty());
+    assertEquals(Integer.valueOf(23), examplePost.getFeedTargeting().getLocales().get(0));
   }
 }


### PR DESCRIPTION
I'm still not seeing the data deserialize correctly.  When we look at the raw returned data for geo locations, it contains a "key" property, which is not a part of NamedFacebookType. 

In addition, the locales property on feed_targeting isn't deserializing as expected.

The modified test demonstrates the issues.  