### PR TITLE
Update FacebookClient.java

### DIFF
--- a/source/library/com/restfb/FacebookClient.java
+++ b/source/library/com/restfb/FacebookClient.java
@@ -956,6 +956,15 @@ public interface FacebookClient {
     public JsonObject getMetaData() {
       return metadata;
     }
+    
+     /**
+     * All Error data associated with access token debug.
+     * 
+     * @return debug token error
+     */
+    public DebugTokenError getDebugTokenError() {
+      return error;
+    }
 
   }
 


### PR DESCRIPTION
When I debug specific token i'm not able to get error message, I noticed that there is no get method for retrieving  DebugTokenError variable associated with DebugTokenInfo class