### PR TITLE
Add missing fields for AdCreativeLinkDataCallToActionValue.

### DIFF
--- a/source/library/com/restfb/types/ads/AdCreativeLinkData.java
+++ b/source/library/com/restfb/types/ads/AdCreativeLinkData.java
@@ -303,6 +303,11 @@ public class AdCreativeLinkData extends AbstractFacebookType {
   @Facebook
   private String picture;
 
+  @Getter
+  @Setter
+  @Facebook("post_click_configuration")
+  private AdCreativePostClickConfiguration postClickConfiguration;
+
   /**
    * List of product IDs provided by the advertiser for Collections
    *

--- a/source/library/com/restfb/types/ads/AdCreativeLinkDataCallToActionValue.java
+++ b/source/library/com/restfb/types/ads/AdCreativeLinkDataCallToActionValue.java
@@ -35,6 +35,18 @@ import lombok.Setter;
 public class AdCreativeLinkDataCallToActionValue extends AbstractFacebookType {
 
   /**
+   * The app destination type.
+   *
+   * -- GETTER --
+   *
+   * @return The app destination type.
+   */
+  @Getter
+  @Setter
+  @Facebook("app_destination")
+  private String appDestination;
+
+  /**
    * Deep link to the app.
    *
    * -- GETTER --
@@ -117,6 +129,18 @@ public class AdCreativeLinkDataCallToActionValue extends AbstractFacebookType {
   @Setter
   @Facebook("link_description")
   private String linkDescription;
+
+  /**
+   * Link format of video.
+   *
+   * -- GETTER --
+   *
+   * @return Link format of video.
+   */
+  @Getter
+  @Setter
+  @Facebook("link_format")
+  private String linkFormat;
 
   /**
    * Title of the link shown in the attachment.

--- a/source/library/com/restfb/types/ads/AdCreativePostClickConfiguration.java
+++ b/source/library/com/restfb/types/ads/AdCreativePostClickConfiguration.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2010-2017 Mark Allen, Norbert Bartels.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.restfb.types.ads;
+
+import com.restfb.Facebook;
+import com.restfb.types.AbstractFacebookType;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class AdCreativePostClickConfiguration extends AbstractFacebookType {
+  @Getter
+  @Setter
+  @Facebook("post_click_item_headline")
+  private String postClickItemHeadline;
+
+  @Getter
+  @Setter
+  @Facebook("post_click_item_description")
+  private String postClickItemDescription;
+}

--- a/source/library/com/restfb/types/ads/AdCreativeVideoData.java
+++ b/source/library/com/restfb/types/ads/AdCreativeVideoData.java
@@ -88,6 +88,11 @@ public class AdCreativeVideoData extends AbstractFacebookType {
 
   @Getter
   @Setter
+  @Facebook("post_click_configuration")
+  private AdCreativePostClickConfiguration postClickConfiguration;
+
+  @Getter
+  @Setter
   @Facebook("retailer_item_ids")
   private List<String> retailerItemIds;
 


### PR DESCRIPTION
Add type for and introduce the missing post_click_configuration field that's referred to at https://developers.facebook.com/docs/marketing-api/guides/collection/v2.9