### PR TITLE
Prevent nullpointer when null quickReplies in Message

### DIFF
--- a/source/library/com/restfb/types/send/Message.java
+++ b/source/library/com/restfb/types/send/Message.java
@@ -95,6 +95,8 @@ public class Message extends AbstractFacebookType {
   }
 
   public List<QuickReply> getQuickReplies() {
+    if(quickReplies == null)
+        return Collections.emptyList();
     return Collections.unmodifiableList(quickReplies);
   }
 


### PR DESCRIPTION
When the quickreplies list in Message is null than the getQuickReplies() method should return an empty list instead of throwing an nullpointer exception. The nullpointer comes from Collections.unmodifiableList that does not accept nulls to be passed as argument.