### PR TITLE
Added convenient toIdMessageRecipient method

### DIFF
--- a/source/library/com/restfb/types/webhook/messaging/MessagingParticipant.java
+++ b/source/library/com/restfb/types/webhook/messaging/MessagingParticipant.java
@@ -23,6 +23,7 @@ package com.restfb.types.webhook.messaging;
 
 import com.restfb.Facebook;
 
+import com.restfb.types.send.IdMessageRecipient;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -34,4 +35,8 @@ public class MessagingParticipant {
   @Setter
   @Facebook
   private String id;
+
+  public IdMessageRecipient toIdMessageRecipient() {
+    return new IdMessageRecipient(id);
+  }
 }


### PR DESCRIPTION
@nbartels I don't know if you like this PR as it might mix some concerns (webhook/sendapi).
So I can understand if you reject it.
But if accepted it gives a easier api to use a sugar syntax to use the `MessagingParticipant` sender as input for the send api.