### PR TITLE
Added convenient has* methods to MessageItem

### DIFF
--- a/source/library/com/restfb/types/webhook/messaging/MessageItem.java
+++ b/source/library/com/restfb/types/webhook/messaging/MessageItem.java
@@ -123,4 +123,31 @@ public class MessageItem implements InnerMessagingItem {
         || "369239343222814".equals(stickerId) // medium size sticker
         || "369239383222810".equals(stickerId); // large size sticker
   }
+
+  /**
+   * Returns whether the message contains an attachment.
+   *
+   * @return {@code true} if the message contains a attachment, {@code false} otherwise
+   */
+  public boolean hasAttachment() {
+    return attachments != null && attachments.size() > 0;
+  }
+
+  /**
+   * Returns whether the message contains a quick reply.
+   *
+   * @return {@code true} if the message contains a quick reply, {@code false} otherwise
+   */
+  public boolean hasQuickReply() {
+    return quickReply != null;
+  }
+
+  /**
+   * Returns whether the message contains a NLP result.
+   *
+   * @return {@code true} if the message contains a NLP result, {@code false} otherwise
+   */
+  public boolean hasNlp() {
+    return nlp != null;
+  }
 }

--- a/source/test/java/com/restfb/types/WebhookMessagingTest.java
+++ b/source/test/java/com/restfb/types/WebhookMessagingTest.java
@@ -85,6 +85,9 @@ public class WebhookMessagingTest extends AbstractJsonMapperTests {
     assertEquals("mid.1458696618141:b4ef9d19ec21086067", item.getMid());
     assertNull(item.getText());
     assertEquals(51L, item.getSeq().longValue());
+    assertFalse(item.hasQuickReply());
+    assertFalse(item.hasNlp());
+    assertTrue(item.hasAttachment());
     assertFalse(item.getAttachments().isEmpty());
     MessagingAttachment attachment = item.getAttachments().get(0);
     assertEquals("image", attachment.getType());
@@ -105,6 +108,9 @@ public class WebhookMessagingTest extends AbstractJsonMapperTests {
     assertEquals("mid.1458696618141:b4ef9d19ec21086067", item.getMid());
     assertNull(item.getText());
     assertEquals(51L, item.getSeq().longValue());
+    assertFalse(item.hasQuickReply());
+    assertFalse(item.hasNlp());
+    assertTrue(item.hasAttachment());
     assertFalse(item.getAttachments().isEmpty());
     MessagingAttachment attachment = item.getAttachments().get(0);
     assertEquals("location", attachment.getType());
@@ -126,6 +132,9 @@ public class WebhookMessagingTest extends AbstractJsonMapperTests {
     assertEquals("mid.1458696618141:b4ef9d19ec21086067", item.getMid());
     assertNull(item.getText());
     assertEquals(51L, item.getSeq().longValue());
+    assertFalse(item.hasQuickReply());
+    assertFalse(item.hasNlp());
+    assertTrue(item.hasAttachment());
     assertFalse(item.getAttachments().isEmpty());
     MessagingAttachment attachment = item.getAttachments().get(0);
     assertEquals("fallback", attachment.getType());
@@ -144,6 +153,9 @@ public class WebhookMessagingTest extends AbstractJsonMapperTests {
     MessagingItem messagingItem = entry.getMessaging().get(0);
     MessageItem item = messagingItem.getMessage();
     assertEquals(item, messagingItem.getItem());
+    assertFalse(item.hasQuickReply());
+    assertFalse(item.hasNlp());
+    assertFalse(item.hasAttachment());
     assertFalse(item.isEcho());
     assertNotNull(item);
     assertEquals("mid.1457764197618:41d102a3e1ae206a38", item.getMid());
@@ -451,6 +463,7 @@ public class WebhookMessagingTest extends AbstractJsonMapperTests {
     MessagingItem messagingItem = entry.getMessaging().get(0);
     MessageItem messageItem = messagingItem.getMessage();
     assertNotNull(messageItem.getNlp());
+    assertTrue(messageItem.hasNlp());
     return messageItem.getNlp();
   }
 }

--- a/source/test/java/com/restfb/types/WebhookTest.java
+++ b/source/test/java/com/restfb/types/WebhookTest.java
@@ -761,8 +761,10 @@ public class WebhookTest extends AbstractJsonMapperTests {
     WebhookObject webhookObject = createJsonMapper()
       .toJavaObject(jsonFromClasspath("webhooks/messaging-message-quickreply"), WebhookObject.class);
     assertNotNull(webhookObject);
-    MessagingItem messageItem = webhookObject.getEntryList().get(0).getMessaging().get(0);
-    QuickReplyItem qrItem = messageItem.getMessage().getQuickReply();
+    MessagingItem item = webhookObject.getEntryList().get(0).getMessaging().get(0);
+    MessageItem messageItem = item.getMessage();
+    assertTrue(messageItem.hasQuickReply());
+    QuickReplyItem qrItem = messageItem.getQuickReply();
     assertNotNull(qrItem);
     assertEquals("PAYLOAD_QUICK_REPLY", qrItem.getPayload());
   }


### PR DESCRIPTION
Added some convenient `has*` methods to `MessageItem` to easily check if item has attachments, quick reply and NLP result.