### PR TITLE
Changed Page.business field type

### DIFF
--- a/src/main/lombok/com/restfb/types/Page.java
+++ b/src/main/lombok/com/restfb/types/Page.java
@@ -230,14 +230,11 @@ public class Page extends CategorizedFacebookType {
 
   /**
    * The Business associated with this Page.
-   * 
-   * @since 1.10.0
-   * @return the Business associated with this Page
    */
   @Getter
   @Setter
   @Facebook
-  private String business;
+  private Business business;
 
   /**
    * Culinary team of the business. Applicable to Restaurants or Nightlife


### PR DESCRIPTION
https://developers.facebook.com/docs/graph-api/reference/page

The field `business` hasn't a string type, it's an object:
```
GET /me?fields=business

{
  "business": {
    "id": "177304729957562",
    "name": "Ddfsss"
  },
  "id": "706221109830695"
}
```