### PR TITLE
Add NEUTRAL as a valid RecommendationType

### DIFF
--- a/src/main/lombok/com/restfb/types/RecommendationType.java
+++ b/src/main/lombok/com/restfb/types/RecommendationType.java
@@ -22,5 +22,5 @@
 package com.restfb.types;
 
 public enum RecommendationType {
-    POSITIVE, NEGATIVE
+    POSITIVE, NEGATIVE, NEUTRAL
 }


### PR DESCRIPTION
I have started noticing that some of my Facebook Page ratings stream messages have a recommendation_type of 'NEUTRAL'. The corresponding enum (RecommendationType) does not include NEUTRAL as one of the valid values for this field which is preventing me from processing these events since a parsing error is thrown.

Here is an example JSON snippet and the stack trace I get with the identifying information removed:

*Event*
```
{"value":{"created_time":1602179746,"item":"rating","open_graph_story_id":"123","review_text":"Review text goes here.","recommendation_type":"NEUTRAL","reviewer_id":"1234","reviewer_name":"Reviewer","verb":"add"},"field":"ratings"}
```

*Stack Trace*
```
com.restfb.exception.FacebookJsonMappingException: Unable to map JSON to Java. Offending JSON is '{"value":{"created_time":1602179746,"item":"rating","open_graph_story_id":"123","review_text":"Review text goes here.","recommendation_type":"NEUTRAL","reviewer_id":"1234","reviewer_name":"Reviewer","verb":"add"},"field":"ratings"}'.
        at com.restfb.DefaultJsonMapper.toJavaObject(DefaultJsonMapper.java:251) ~[dep-plugin-facebook-cdf5a183-d7c4-49cf-89b7-b0ffd84e95e1.jar.1602173437000:?]
        at com.restfb.DefaultJsonMapper.toJavaList(DefaultJsonMapper.java:138) ~[dep-plugin-facebook-cdf5a183-d7c4-49cf-89b7-b0ffd84e95e1.jar.1602173437000:?]
        at com.restfb.DefaultJsonMapper.toJavaType(DefaultJsonMapper.java:638) ~[dep-plugin-facebook-cdf5a183-d7c4-49cf-89b7-b0ffd84e95e1.jar.1602173437000:?]
        at com.restfb.DefaultJsonMapper.toJavaObject(DefaultJsonMapper.java:233) ~[dep-plugin-facebook-cdf5a183-d7c4-49cf-89b7-b0ffd84e95e1.jar.1602173437000:?]
        at com.restfb.DefaultJsonMapper.toJavaList(DefaultJsonMapper.java:138) ~[dep-plugin-facebook-cdf5a183-d7c4-49cf-89b7-b0ffd84e95e1.jar.1602173437000:?]
        at com.restfb.DefaultJsonMapper.toJavaType(DefaultJsonMapper.java:638) ~[dep-plugin-facebook-cdf5a183-d7c4-49cf-89b7-b0ffd84e95e1.jar.1602173437000:?]
        at com.restfb.DefaultJsonMapper.toJavaObject(DefaultJsonMapper.java:233) ~[dep-plugin-facebook-cdf5a183-d7c4-49cf-89b7-b0ffd84e95e1.jar.1602173437000:?]
         ....<omitted>...
Caused by: java.lang.reflect.InvocationTargetException
        at sun.reflect.GeneratedMethodAccessor65.invoke(Unknown Source) ~[?:?]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_202]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_202]
        at com.restfb.DefaultJsonMapper.invokeJsonMappingCompletedMethods(DefaultJsonMapper.java:286) ~[dep-plugin-facebook-cdf5a183-d7c4-49cf-89b7-b0ffd84e95e1.jar.1602173437000:?]
        at com.restfb.DefaultJsonMapper.toJavaObject(DefaultJsonMapper.java:245) ~[dep-plugin-facebook-cdf5a183-d7c4-49cf-89b7-b0ffd84e95e1.jar.1602173437000:?]
        ... 18 more
Caused by: com.restfb.exception.FacebookJsonMappingException: Don't know how to map JSON to class com.restfb.types.RecommendationType. Are you sure you're mapping to the right class?
Offending JSON is 'NEUTRAL'.
        at com.restfb.DefaultJsonMapper.toPrimitiveJavaType(DefaultJsonMapper.java:549) ~[dep-plugin-facebook-cdf5a183-d7c4-49cf-89b7-b0ffd84e95e1.jar.1602173437000:?]
        at com.restfb.DefaultJsonMapper.toJavaObject(DefaultJsonMapper.java:180) ~[dep-plugin-facebook-cdf5a183-d7c4-49cf-89b7-b0ffd84e95e1.jar.1602173437000:?]
        at com.restfb.DefaultJsonMapper.toJavaType(DefaultJsonMapper.java:696) ~[dep-plugin-facebook-cdf5a183-d7c4-49cf-89b7-b0ffd84e95e1.jar.1602173437000:?]
        at com.restfb.DefaultJsonMapper.toJavaObject(DefaultJsonMapper.java:233) ~[dep-plugin-facebook-cdf5a183-d7c4-49cf-89b7-b0ffd84e95e1.jar.1602173437000:?]
        at com.restfb.types.webhook.ChangeValueFactory.buildWithMapper(ChangeValueFactory.java:99) ~[dep-plugin-facebook-cdf5a183-d7c4-49cf-89b7-b0ffd84e95e1.jar.1602173437000:?]
        at com.restfb.types.webhook.Change.convertChangeValue(Change.java:57) ~[dep-plugin-facebook-cdf5a183-d7c4-49cf-89b7-b0ffd84e95e1.jar.1602173437000:?]
        at sun.reflect.GeneratedMethodAccessor65.invoke(Unknown Source) ~[?:?]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_202]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_202]
        at com.restfb.DefaultJsonMapper.invokeJsonMappingCompletedMethods(DefaultJsonMapper.java:286) ~[dep-plugin-facebook-cdf5a183-d7c4-49cf-89b7-b0ffd84e95e1.jar.1602173437000:?]
        at com.restfb.DefaultJsonMapper.toJavaObject(DefaultJsonMapper.java:245) ~[dep-plugin-facebook-cdf5a183-d7c4-49cf-89b7-b0ffd84e95e1.jar.1602173437000:?]
        ... 18 more
```