### PR TITLE
granular_scopes added to DebugTokenInfo

### DIFF
--- a/src/main/java/com/restfb/FacebookClient.java
+++ b/src/main/java/com/restfb/FacebookClient.java
@@ -776,6 +776,12 @@ public interface FacebookClient {
     @Facebook
     private List<String> scopes = new ArrayList<>();
 
+    /**
+     * List of granular permissions that the user has granted for this app in this access token.
+     */
+    @Facebook("granular_scopes")
+    private List<GranularScope> granularScopes = new ArrayList<>();
+
     @Facebook
     private String type;
 
@@ -852,6 +858,15 @@ public interface FacebookClient {
     }
 
     /**
+     * List of granular scopes the access token 'contains'
+     * 
+     * @return list of granular scopes
+     */
+    public List<GranularScope> getGranularScopes() {
+      return unmodifiableList(granularScopes);
+    }
+
+    /**
      * General metadata associated with the access token. Can contain data like 'sso', 'auth_type', 'auth_nonce'
      * 
      * @return General metadata associated with the access token
@@ -871,6 +886,41 @@ public interface FacebookClient {
 
     public String getType() {
       return type;
+    }
+  }
+
+  class GranularScope extends AbstractFacebookType {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The permission granted by the user.
+     */
+    @Facebook
+    private String scope;
+
+    /**
+     * The target ids of Pages, Groups, or business assets the user granted the above permission for.
+     */
+    @Facebook("target_ids")
+    private List<String> targetIds = new ArrayList<>();
+
+    /**
+     * The permission granted by the user.
+     * 
+     * @return The permission granted by the user.
+     */
+    public String getScope() {
+      return scope;
+    }
+
+    /**
+     * The target ids of Pages, Groups, or business assets the user granted the above permission for.
+     * 
+     * @return The target ids of Pages, Groups, or business assets the user granted the above permission for.
+     */
+    public List<String> getTargetIds() {
+      return unmodifiableList(targetIds);
     }
   }
 

--- a/src/test/java/com/restfb/types/DebugTokenInfoTest.java
+++ b/src/test/java/com/restfb/types/DebugTokenInfoTest.java
@@ -63,4 +63,22 @@ class DebugTokenInfoTest extends AbstractJsonMapperTests {
     assertEquals("1234567890", exampleDebugTokenInfo.getAppId());
     assertEquals(1561330800000L, exampleDebugTokenInfo.getExpiresAt().getTime());
   }
+
+  @Test
+  void testJsonWithGranularScopes() {
+    FacebookClient.DebugTokenInfo exampleDebugTokenInfo =
+        createJsonMapper().toJavaObject(jsonFromClasspath("debug-token-info-3"), FacebookClient.DebugTokenInfo.class);
+    assertNotNull(exampleDebugTokenInfo);
+    assertNotNull(exampleDebugTokenInfo.getGranularScopes());
+    assertEquals(2, exampleDebugTokenInfo.getGranularScopes().size());
+
+    assertEquals("pages_show_list", exampleDebugTokenInfo.getGranularScopes().get(0).getScope());
+    assertNotNull(exampleDebugTokenInfo.getGranularScopes().get(0).getTargetIds());
+    assertEquals(0, exampleDebugTokenInfo.getGranularScopes().get(0).getTargetIds().size());
+
+    assertEquals("instagram_basic", exampleDebugTokenInfo.getGranularScopes().get(1).getScope());
+    assertNotNull(exampleDebugTokenInfo.getGranularScopes().get(1).getTargetIds());
+    assertEquals(1, exampleDebugTokenInfo.getGranularScopes().get(1).getTargetIds().size());
+    assertEquals("{connected-ig-user-id}", exampleDebugTokenInfo.getGranularScopes().get(1).getTargetIds().get(0));
+  }
 }

--- a/src/test/resources/json/debug-token-info-3.json
+++ b/src/test/resources/json/debug-token-info-3.json
@@ -1,0 +1,25 @@
+{
+  "app_id": "{app-id}",
+  "type": "USER",
+  "application": "{app-name}",
+  "data_access_expires_at": 1649504517,
+  "expires_at": 1641733200,
+  "is_valid": true,
+  "scopes": [
+    "pages_show_list",
+    "instagram_basic",
+    "public_profile"
+  ],
+  "granular_scopes": [
+    {
+      "scope": "pages_show_list"
+    },
+    {
+      "scope": "instagram_basic",
+      "target_ids": [
+        "{connected-ig-user-id}"
+      ]
+    }
+  ],
+  "user_id": "{user-id}"
+}


### PR DESCRIPTION
The /debug_token endpoint's response contains the field "granular_scopes" which is not mapped in FacebookClient.DebugTokenInfo:

```
"granular_scopes":[
  {
    "scope":"pages_show_list",
    "target_ids":[
      "{page-1-app-can-access-id}",
      "{page-2-app-can-access-id}"
    ]
  }
]
```

The target_ids field is ommitted if a user grants an app a specific permission in general and not for only a subset of possible Pages, Groups, Instagram Accounts, etc.

Graph API Docs: https://developers.facebook.com/docs/facebook-login/access-tokens/debugging-and-error-handling
Facebook Login Docs: https://developers.facebook.com/docs/facebook-login/permissions/overview#granularpermissions