### PR TITLE
Add method to generate Facebook Business Login URL

### DIFF
--- a/src/main/java/com/restfb/DefaultFacebookClient.java
+++ b/src/main/java/com/restfb/DefaultFacebookClient.java
@@ -635,6 +635,20 @@ public class DefaultFacebookClient extends BaseFacebookClient implements Faceboo
     return getLoginDialogUrl(appId, redirectUri, scope, null, parameters);
   }
 
+  @Override
+  public String getBusinessLoginDialogUrl(String appId, String redirectUri, String configId, String state,
+                                          Parameter... parameters) {
+    verifyParameterPresence("configId", configId);
+
+    List<Parameter> parameterList = new ArrayList<>(asList(parameters));
+    parameterList.add(Parameter.with("config_id", configId));
+    parameterList.add(Parameter.with("response_type", "code"));
+    parameterList.add(Parameter.with("override_default_response_type", true));
+
+    return getGenericLoginDialogUrl(appId, redirectUri, new ScopeBuilder(true),
+            () -> getFacebookEndpointUrls().getFacebookEndpoint() + "/dialog/oauth", state, parameterList);
+  }
+
   protected String getGenericLoginDialogUrl(String appId, String redirectUri, ScopeBuilder scope,
       Supplier<String> endpointSupplier, String state, List<Parameter> parameters) {
     verifyParameterPresence(APP_ID, appId);

--- a/src/main/java/com/restfb/DefaultThreadsClient.java
+++ b/src/main/java/com/restfb/DefaultThreadsClient.java
@@ -152,4 +152,9 @@ public class DefaultThreadsClient extends DefaultFacebookClient {
       return getFacebookEndpointUrls().getThreadsApiEndpoint();
     }
   }
+
+  @Override
+  public String getBusinessLoginDialogUrl(String appId, String redirectUri, String configId, String state, Parameter... parameters) {
+    throw new UnsupportedOperationException("Facebook Login for Business is not supported in the Threads API.");
+  }
 }

--- a/src/main/java/com/restfb/FacebookClient.java
+++ b/src/main/java/com/restfb/FacebookClient.java
@@ -596,4 +596,23 @@ public interface FacebookClient {
    */
   String getLoginDialogUrl(String appId, String redirectUri, ScopeBuilder scope, Parameter... additionalParameters);
 
+  /**
+   * Generates the login dialog url for Business
+   *
+   * @param appId
+   *          The ID of your app, found in your app's dashboard.
+   * @param redirectUri
+   *          The URL that you want to redirect the person logging in back to. This URL will capture the response from
+   *          the Login Dialog. If you are using this in a webview within a desktop app, this must be set to
+   *          <code>https://www.facebook.com/connect/login_success.html</code>.
+   * @param configId
+   *          The configuration ID that defines the permissions and settings, found in the product section of your
+   *          app's dashboard.
+   * @param state
+   *         An optional string used to maintain state between the request and the callback.
+   * @param parameters
+   *          List of additional parameters
+   * @return the login dialog url
+   */
+  String getBusinessLoginDialogUrl(String appId, String redirectUri, String configId, String state, Parameter... parameters);
 }

--- a/src/test/java/com/restfb/FacebookClientTest.java
+++ b/src/test/java/com/restfb/FacebookClientTest.java
@@ -397,6 +397,25 @@ class FacebookClientTest {
   }
 
   @Test
+  void checkBusinessLoginDialogURL() {
+    FacebookClient client = new DefaultFacebookClient(Version.LATEST);
+    String loginDialogUrlString =
+            client.getBusinessLoginDialogUrl("123456", "http://www.example.com", "1234", "state3456");
+    assertThat(loginDialogUrlString).isEqualTo(
+            "https://www.facebook.com/dialog/oauth?client_id=123456&redirect_uri=http%3A%2F%2Fwww.example.com&state=state3456&config_id=1234&response_type=code&override_default_response_type=true");
+  }
+
+  @Test
+  void checkBusinessLoginDialogURLAdditionalParameters() {
+    FacebookClient client = new DefaultFacebookClient(Version.LATEST);
+    String loginDialogUrlString =
+            client.getBusinessLoginDialogUrl("123456", "http://www.example.com", "1234", "state3456",
+                    Parameter.with("extras", "{sessionInfoVersion: '3'}"));
+    assertThat(loginDialogUrlString).isEqualTo(
+            "https://www.facebook.com/dialog/oauth?client_id=123456&redirect_uri=http%3A%2F%2Fwww.example.com&state=state3456&extras=%7BsessionInfoVersion%3A+%273%27%7D&config_id=1234&response_type=code&override_default_response_type=true");
+  }
+
+  @Test
   void checkThreadsDialogURLAdditionalParameters() {
     FacebookClient client = new DefaultThreadsClient(Version.LATEST);
     String loginDialogUrlString = client.getLoginDialogUrl("1234", "http://www.example.com", new ScopeBuilder(true),


### PR DESCRIPTION
This PR introduces a new method, `getBusinessLoginDialogUrl`, which generates the login dialog URL for Facebook Business authentication using OAuth.

Why?
- [Facebook Login for Business](https://developers.facebook.com/docs/facebook-login/facebook-login-for-business#get-started) no longer uses `scope` for permission management; instead, it now requires `config_id`.
- This method ensures compliance with Facebook’s latest authentication requirements, including `response_type=code` for OAuth flows.