### PR TITLE
Add type for mapping WhatsApp Business Phone Number

### DIFF
--- a/src/main/lombok/com/restfb/types/whatsapp/WhatsAppBusinessConversationalComponent.java
+++ b/src/main/lombok/com/restfb/types/whatsapp/WhatsAppBusinessConversationalComponent.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2010-2025 Mark Allen, Norbert Bartels.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.restfb.types.whatsapp;
+
+import com.restfb.Facebook;
+import com.restfb.types.AbstractFacebookType;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents the
+ * <a href="https://developers.facebook.com/docs/whatsapp/cloud-api/phone-numbers/conversational-components/#configuring-via-the-api">
+ * Conversational Components</a>
+ */
+public class WhatsAppBusinessConversationalComponent extends AbstractFacebookType {
+
+  private static final long serialVersionUID = 1L;
+
+  @Getter
+  @Setter
+  @Facebook("enable_welcome_message")
+  private boolean enableWelcomeMessage;
+
+  @Getter
+  @Setter
+  @Facebook
+  private List<String> prompts = new ArrayList<>();
+
+  @Getter
+  @Setter
+  @Facebook
+  private List<Command> commands = new ArrayList<>();
+
+  public static class Command {
+    @Getter
+    @Setter
+    @Facebook("command_name")
+    private String commandName;
+
+    @Getter
+    @Setter
+    @Facebook("command_description")
+    private String commandDescription;
+  }
+}

--- a/src/main/lombok/com/restfb/types/whatsapp/WhatsAppBusinessHealthStatus.java
+++ b/src/main/lombok/com/restfb/types/whatsapp/WhatsAppBusinessHealthStatus.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2010-2025 Mark Allen, Norbert Bartels.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.restfb.types.whatsapp;
+
+import com.restfb.Facebook;
+import com.restfb.types.AbstractFacebookType;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents the
+ * <a href="https://developers.facebook.com/docs/whatsapp/cloud-api/health-status/#response-contents">
+ * Messaging Health Status</a>
+ */
+public class WhatsAppBusinessHealthStatus extends AbstractFacebookType {
+
+  private static final long serialVersionUID = 1L;
+
+  // Indicates the overall messaging capability of the business phone number
+  @Getter
+  @Setter
+  @Facebook("can_send_message")
+  private CanSendMessageStatus canSendMessage;
+
+  // List of entities and their messaging status
+  @Getter
+  @Setter
+  @Facebook
+  private List<EntityStatus> entities = new ArrayList<>();
+
+  public enum CanSendMessageStatus {
+    AVAILABLE, LIMITED, BLOCKED
+  }
+
+  public enum EntityType {
+    PHONE_NUMBER, WABA, BUSINESS, APP, MESSAGE_TEMPLATE
+  }
+
+  public static class EntityStatus {
+    // Type of entity (PHONE_NUMBER, WABA, BUSINESS, APP, MESSAGE_TEMPLATE)
+    @Getter
+    @Setter
+    @Facebook("entity_type")
+    private EntityType entityType;
+
+    // ID of the entity
+    @Getter
+    @Setter
+    @Facebook
+    private String id;
+
+    // Messaging capability status of the entity
+    @Getter
+    @Setter
+    @Facebook("can_send_message")
+    private CanSendMessageStatus canSendMessage;
+
+    // Additional information about messaging limitations
+    @Getter
+    @Setter
+    @Facebook("additional_info")
+    private List<String> additionalInfo = new ArrayList<>();
+
+    // List of errors if the entity is blocked from sending messages
+    @Getter
+    @Setter
+    @Facebook
+    private List<ErrorDetail> errors = new ArrayList<>();
+  }
+
+  public static class ErrorDetail {
+    // Error code representing the specific issue
+    @Getter
+    @Setter
+    @Facebook("error_code")
+    private int errorCode;
+
+    // Description of the error
+    @Getter
+    @Setter
+    @Facebook("error_description")
+    private String errorDescription;
+
+    // Suggested solution for resolving the error
+    @Getter
+    @Setter
+    @Facebook("possible_solution")
+    private String possibleSolution;
+  }
+}

--- a/src/main/lombok/com/restfb/types/whatsapp/WhatsAppBusinessPhoneNumber.java
+++ b/src/main/lombok/com/restfb/types/whatsapp/WhatsAppBusinessPhoneNumber.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2010-2025 Mark Allen, Norbert Bartels.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.restfb.types.whatsapp;
+
+import com.restfb.Facebook;
+import com.restfb.JsonMapper.JsonMappingCompleted;
+import com.restfb.types.AbstractFacebookType;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Date;
+
+/**
+ * Represents the
+ * <a href="https://developers.facebook.com/docs/graph-api/reference/whats-app-business-account-to-number-current-status#fields">
+ * WhatsApp Business Phone Number</a>
+ */
+public class WhatsAppBusinessPhoneNumber extends AbstractFacebookType {
+
+  private static final long serialVersionUID = 1L;
+
+  // WhatsApp business phone number ID
+  @Getter
+  @Setter
+  @Facebook
+  private String id;
+
+  // The account mode of the phone number
+  @Getter
+  @Setter
+  @Facebook("account_mode")
+  private AccountMode accountMode;
+
+  // The certificate of the WhatsApp business phone number
+  @Getter
+  @Setter
+  @Facebook
+  private String certificate;
+
+  // The verification status of the phone number's OTP (One-Time Password) (Default)
+  @Getter
+  @Setter
+  @Facebook("code_verification_status")
+  private CodeVerificationStatus codeVerificationStatus;
+
+  // Configuration for WhatsApp Business conversational automation
+  @Getter
+  @Setter
+  @Facebook("conversational_automation")
+  private WhatsAppBusinessConversationalComponent conversationAutomation;
+
+  // WhatsApp business phone number in international format (Default)
+  @Getter
+  @Setter
+  @Facebook("display_phone_number")
+  private String displayPhoneNumber;
+
+  // Status of eligibility in the API Business Global Search
+  @Getter
+  @Setter
+  @Facebook("eligibility_for_api_business_global_search")
+  private String eligibilityForApiBusinessGlobalSearch;
+
+  // Health status of the WhatsApp Business number (used for messaging diagnostics)
+  @Getter
+  @Setter
+  @Facebook("health_status")
+  private WhatsAppBusinessHealthStatus healthStatus;
+
+  // Indicates if the phone number is associated with an Official Business Account
+  @Getter
+  @Setter
+  @Facebook("is_official_business_account")
+  private Boolean isOfficialBusinessAccount;
+
+  // Indicates if the phone number is used in the WhatsApp Business app
+  @Getter
+  @Setter
+  @Facebook("is_on_biz_app")
+  private Boolean isOnBizApp;
+
+  // Indicates if two-step verification is enabled for this phone number
+  @Getter
+  @Setter
+  @Facebook("is_pin_enabled")
+  private Boolean isPinEnabled;
+
+  // Indicates if the phone number is pre-verified
+  @Getter
+  @Setter
+  @Facebook("is_preverified_number")
+  private Boolean isPreverifiedNumber;
+
+  // The date and time when the phone number was added to the WhatsApp Business Account (Default)
+  @Getter
+  @Setter
+  @Facebook("last_onboarded_time")
+  private Date lastOnboardedTime;
+
+  // The messaging limit tier assigned to the phone number
+  @Getter
+  @Setter
+  @Facebook("messaging_limit_tier")
+  private MessagingLimitTier messagingLimitTier;
+
+  // The status of the phone number’s display name review
+  @Getter
+  @Setter
+  @Facebook("name_status")
+  private NameStatus nameStatus;
+
+  // The certificate of the newly requested name
+  @Getter
+  @Setter
+  @Facebook("new_certificate")
+  private String newCertificate;
+
+  // The status of the review of the new requested name
+  @Getter
+  @Setter
+  @Facebook("new_name_status")
+  private NameStatus newNameStatus;
+
+  // The platform where the business phone number is registered (Default)
+  @Getter
+  @Setter
+  @Facebook("platform_type")
+  private PlatformType platformType;
+
+  // The quality rating of the WhatsApp business phone number
+  @Getter
+  @Setter
+  @Facebook("quality_score")
+  private WhatsAppPhoneQualityScoreShape qualityScore;
+
+  // The availability of the phone number in WhatsApp Business Search
+  @Getter
+  @Setter
+  @Facebook("search_visibility")
+  private String searchVisibility;
+
+  // The operational status of the phone number
+  @Getter
+  @Setter
+  @Facebook
+  private Status status;
+
+  // The throughput level for Cloud API (Default)
+  @Getter
+  @Setter
+  @Facebook
+  private Throughput throughput;
+
+  // The verified name that appears in WhatsApp Manager and client chat headers (Default)
+  @Getter
+  @Setter
+  @Facebook("verified_name")
+  private String verifiedName;
+
+  @Facebook("quality_rating")
+  private String qualityRating;
+
+  @JsonMappingCompleted
+  protected void fillQualityScore() {
+    if (this.qualityScore != null || this.qualityRating == null) return;
+
+    WhatsAppPhoneQualityScoreShape qualityScore = new WhatsAppPhoneQualityScoreShape();
+    qualityScore.setScore(this.qualityRating);
+
+    this.qualityScore = qualityScore;
+  }
+
+  public enum AccountMode {
+    SANDBOX, LIVE
+  }
+
+  public enum CodeVerificationStatus {
+    NOT_VERIFIED, VERIFIED, EXPIRED
+  }
+
+  public enum Status {
+    PENDING, DELETED, MIGRATED, BANNED, RESTRICTED, RATE_LIMITED, FLAGGED, CONNECTED, DISCONNECTED, UNKNOWN, UNVERIFIED
+  }
+
+  public enum MessagingLimitTier {
+    TIER_50, TIER_250, TIER_1K, TIER_10K, TIER_100K, TIER_UNLIMITED
+  }
+
+  public enum NameStatus {
+    NONE, NON_EXISTS, PENDING_REVIEW, AVAILABLE_WITHOUT_REVIEW, EXPIRED, APPROVED, DECLINED
+  }
+
+  public enum PlatformType {
+    CLOUD_API, ON_PREMISE, NOT_APPLICABLE
+  }
+
+  public static class Throughput {
+    // Error code representing the specific issue
+    @Getter
+    @Setter
+    @Facebook
+    private Level level;
+
+    public enum Level {
+      STANDARD, HIGH, NOT_APPLICABLE
+    }
+  }
+}
+

--- a/src/test/java/com/restfb/types/whatsapp/WhatsAppBusinessPhoneNumberTest.java
+++ b/src/test/java/com/restfb/types/whatsapp/WhatsAppBusinessPhoneNumberTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2010-2025 Mark Allen, Norbert Bartels.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.restfb.types.whatsapp;
+
+import com.restfb.AbstractJsonMapperTests;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class WhatsAppBusinessPhoneNumberTest extends AbstractJsonMapperTests {
+
+  @Test
+  void checkDeserializeDefaultResponse() {
+    WhatsAppBusinessPhoneNumber phoneNumber = createJsonMapper().toJavaObject(
+            jsonFromClasspath("whatsapp/phone-number-default-response"),
+            WhatsAppBusinessPhoneNumber.class);
+
+    assertNotNull(phoneNumber);
+    assertEquals("Business Phone Numbers Name", phoneNumber.getVerifiedName());
+    assertEquals(WhatsAppBusinessPhoneNumber.CodeVerificationStatus.EXPIRED, phoneNumber.getCodeVerificationStatus());
+    assertEquals("+593 99 999 9999", phoneNumber.getDisplayPhoneNumber());
+    assertEquals("GREEN", phoneNumber.getQualityScore().getScore());
+    assertEquals(WhatsAppBusinessPhoneNumber.PlatformType.CLOUD_API, phoneNumber.getPlatformType());
+    assertEquals(WhatsAppBusinessPhoneNumber.Throughput.Level.STANDARD, phoneNumber.getThroughput().getLevel());
+    assertEquals("999999999999999", phoneNumber.getId());
+    assertNotNull(phoneNumber.getLastOnboardedTime());
+  }
+
+  @Test
+  void checkDeserializeFullResponse() {
+    WhatsAppBusinessPhoneNumber phoneNumber = createJsonMapper().toJavaObject(
+            jsonFromClasspath("whatsapp/phone-number-full-response"),
+            WhatsAppBusinessPhoneNumber.class);
+
+    // Validate main fields
+    assertNotNull(phoneNumber);
+    assertEquals("certificate", phoneNumber.getCertificate());
+    assertEquals("new_certificate", phoneNumber.getNewCertificate());
+    assertEquals(WhatsAppBusinessPhoneNumber.AccountMode.LIVE, phoneNumber.getAccountMode());
+    assertEquals(WhatsAppBusinessPhoneNumber.CodeVerificationStatus.EXPIRED, phoneNumber.getCodeVerificationStatus());
+    assertEquals("+593 99 999 9999", phoneNumber.getDisplayPhoneNumber());
+    assertEquals("NON_ELIGIBLE_NUMBER_OUTSIDE_ROLLOUT_COUNTRIES", phoneNumber.getEligibilityForApiBusinessGlobalSearch());
+    assertEquals(WhatsAppBusinessPhoneNumber.MessagingLimitTier.TIER_1K, phoneNumber.getMessagingLimitTier());
+    assertEquals(WhatsAppBusinessPhoneNumber.NameStatus.APPROVED, phoneNumber.getNameStatus());
+    assertEquals(WhatsAppBusinessPhoneNumber.PlatformType.CLOUD_API, phoneNumber.getPlatformType());
+    assertEquals(WhatsAppBusinessPhoneNumber.Status.CONNECTED, phoneNumber.getStatus());
+    assertEquals("Business Phone Numbers Name", phoneNumber.getVerifiedName());
+
+    // Validate boolean fields
+    assertFalse(phoneNumber.getIsOfficialBusinessAccount());
+    assertFalse(phoneNumber.getIsOnBizApp());
+    assertTrue(phoneNumber.getIsPinEnabled());
+    assertFalse(phoneNumber.getIsPreverifiedNumber());
+
+    // Validate throughput field
+    assertEquals(WhatsAppBusinessPhoneNumber.Throughput.Level.STANDARD, phoneNumber.getThroughput().getLevel());
+
+    // Validate HealthStatus
+    assertNotNull(phoneNumber.getHealthStatus());
+    assertEquals(WhatsAppBusinessHealthStatus.CanSendMessageStatus.BLOCKED, phoneNumber.getHealthStatus().getCanSendMessage());
+    assertEquals(4, phoneNumber.getHealthStatus().getEntities().size());
+
+    // Validate first HealthStatus entity
+    WhatsAppBusinessHealthStatus.EntityStatus entity = phoneNumber.getHealthStatus().getEntities().get(0);
+    assertEquals(WhatsAppBusinessHealthStatus.EntityType.PHONE_NUMBER, entity.getEntityType());
+    assertEquals("999999999999999", entity.getId());
+    assertEquals(WhatsAppBusinessHealthStatus.CanSendMessageStatus.BLOCKED, entity.getCanSendMessage());
+    assertFalse(entity.getErrors().isEmpty());
+
+    assertEquals(141000, entity.getErrors().get(0).getErrorCode());
+    assertEquals("The phone number you are trying to send messages from is not linked to your WhatsApp account.", entity.getErrors().get(0).getErrorDescription());
+    assertEquals("Register and finish the OTP authentication process for your phone number.", entity.getErrors().get(0).getPossibleSolution());
+
+    assertFalse(entity.getAdditionalInfo().isEmpty());
+    assertEquals("Your display name has not been approved yet. Your message limit will increase after the display name is approved.", entity.getAdditionalInfo().get(0));
+
+    // Validate Conversation Automation
+    WhatsAppBusinessConversationalComponent conversationalComponent = phoneNumber.getConversationAutomation();
+    assertNotNull(conversationalComponent);
+    assertTrue(conversationalComponent.isEnableWelcomeMessage());
+
+    assertNotNull(conversationalComponent.getPrompts());
+    assertEquals(2, conversationalComponent.getPrompts().size());
+    assertEquals("Find the best hotels in the area", conversationalComponent.getPrompts().get(0));
+    assertEquals("Find deals on rental cars", conversationalComponent.getPrompts().get(1));
+
+    assertNotNull(conversationalComponent.getCommands());
+    assertEquals(2, conversationalComponent.getCommands().size());
+    assertEquals("tickets", conversationalComponent.getCommands().get(0).getCommandName());
+    assertEquals("Book flight tickets", conversationalComponent.getCommands().get(0).getCommandDescription());
+    assertEquals("hotel", conversationalComponent.getCommands().get(1).getCommandName());
+    assertEquals("Book hotel", conversationalComponent.getCommands().get(1).getCommandDescription());
+
+    // Validate Quality Score
+    assertNotNull(phoneNumber.getQualityScore());
+    assertEquals("GREEN", phoneNumber.getQualityScore().getScore());
+    assertEquals(1739513802, phoneNumber.getQualityScore().getDate());
+    assertEquals("reason", phoneNumber.getQualityScore().getReasons().get(0));
+  }
+
+  @Test
+  void checkListsNotNullWhenMissingInJson() {
+    WhatsAppBusinessPhoneNumber phoneNumber = createJsonMapper().toJavaObject(
+            jsonFromClasspath("whatsapp/phone-number-missing-lists"),
+            WhatsAppBusinessPhoneNumber.class);
+
+    assertNotNull(phoneNumber);
+
+    assertNotNull(phoneNumber.getConversationAutomation());
+    assertNotNull(phoneNumber.getConversationAutomation().getPrompts());
+    assertNotNull(phoneNumber.getConversationAutomation().getCommands());
+
+    assertNotNull(phoneNumber.getHealthStatus());
+    assertNotNull(phoneNumber.getHealthStatus().getEntities());
+    assertNotNull(phoneNumber.getHealthStatus().getEntities().get(0).getAdditionalInfo());
+    assertNotNull(phoneNumber.getHealthStatus().getEntities().get(0).getErrors());
+
+    assertNotNull(phoneNumber.getQualityScore());
+    assertNotNull(phoneNumber.getQualityScore().getReasons());
+  }
+}

--- a/src/test/resources/json/whatsapp/phone-number-default-response.json
+++ b/src/test/resources/json/whatsapp/phone-number-default-response.json
@@ -1,0 +1,15 @@
+{
+  "verified_name": "Business Phone Numbers Name",
+  "code_verification_status": "EXPIRED",
+  "display_phone_number": "+593 99 999 9999",
+  "quality_rating": "GREEN",
+  "platform_type": "CLOUD_API",
+  "throughput": {
+    "level": "STANDARD"
+  },
+  "last_onboarded_time": "2025-02-04T17:40:07+0000",
+  "webhook_configuration": {
+    "application": "https://example.com/webhook"
+  },
+  "id": "999999999999999"
+}

--- a/src/test/resources/json/whatsapp/phone-number-full-response.json
+++ b/src/test/resources/json/whatsapp/phone-number-full-response.json
@@ -1,0 +1,83 @@
+{
+  "account_mode": "LIVE",
+  "certificate": "certificate",
+  "new_certificate": "new_certificate",
+  "code_verification_status": "EXPIRED",
+  "display_phone_number": "+593 99 999 9999",
+  "eligibility_for_api_business_global_search": "NON_ELIGIBLE_NUMBER_OUTSIDE_ROLLOUT_COUNTRIES",
+  "health_status": {
+    "can_send_message": "BLOCKED",
+    "entities": [
+      {
+        "entity_type": "PHONE_NUMBER",
+        "id": "999999999999999",
+        "can_send_message": "BLOCKED",
+        "errors": [
+          {
+            "error_code": 141000,
+            "error_description": "The phone number you are trying to send messages from is not linked to your WhatsApp account.",
+            "possible_solution": "Register and finish the OTP authentication process for your phone number."
+          }
+        ],
+        "additional_info": [
+          "Your display name has not been approved yet. Your message limit will increase after the display name is approved."
+        ]
+      },
+      {
+        "entity_type": "WABA",
+        "id": "999999999999999",
+        "can_send_message": "AVAILABLE"
+      },
+      {
+        "entity_type": "BUSINESS",
+        "id": "999999999999999",
+        "can_send_message": "AVAILABLE"
+      },
+      {
+        "entity_type": "APP",
+        "id": "999999999999999",
+        "can_send_message": "AVAILABLE"
+      }
+    ]
+  },
+  "is_official_business_account": false,
+  "is_on_biz_app": false,
+  "is_pin_enabled": true,
+  "is_preverified_number": false,
+  "last_onboarded_time": "2025-02-04T17:40:07+0000",
+  "messaging_limit_tier": "TIER_1K",
+  "name_status": "APPROVED",
+  "new_name_status": "NONE",
+  "platform_type": "CLOUD_API",
+  "quality_score": {
+    "date": 1739513802,
+    "score": "GREEN",
+    "reasons": [
+      "reason"
+    ]
+  },
+  "search_visibility": "NON_VISIBLE",
+  "status": "CONNECTED",
+  "throughput": {
+    "level": "STANDARD"
+  },
+  "verified_name": "Business Phone Numbers Name",
+  "conversational_automation": {
+    "enable_welcome_message": true,
+    "prompts": [
+      "Find the best hotels in the area",
+      "Find deals on rental cars"
+    ],
+    "commands": [
+      {
+        "command_name": "tickets",
+        "command_description": "Book flight tickets"
+      },
+      {
+        "command_name": "hotel",
+        "command_description": "Book hotel"
+      }
+    ]
+  },
+  "id": "999999999999999"
+}

--- a/src/test/resources/json/whatsapp/phone-number-missing-lists.json
+++ b/src/test/resources/json/whatsapp/phone-number-missing-lists.json
@@ -1,0 +1,10 @@
+{
+  "conversational_automation": {},
+  "health_status": {
+    "entities": [
+      {}
+    ]
+  },
+  "quality_score": {},
+  "throughput": {}
+}


### PR DESCRIPTION
This PR adds the `WhatsAppBusinessPhoneNumber` class to map [WhatsApp Business Phone Number](https://developers.facebook.com/docs/graph-api/reference/whats-app-business-account-to-number-current-status/#fields), including classes for fields `health_status`, `conversational_automation` and enums for other relevant attributes.