### PR TITLE
Add missing fields for `WhatsAppMessageTemplateComponent` Type

### DIFF
--- a/src/main/lombok/com/restfb/types/whatsapp/WhatsAppMessageTemplateComponent.java
+++ b/src/main/lombok/com/restfb/types/whatsapp/WhatsAppMessageTemplateComponent.java
@@ -21,35 +21,81 @@
  */
 package com.restfb.types.whatsapp;
 
-import java.util.List;
-
 import com.restfb.Facebook;
 import com.restfb.types.AbstractFacebookType;
-
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents the
+ * <a href="https://developers.facebook.com/docs/graph-api/reference/whats-app-business-hsm-whats-app-hsm-component-get/">
+ * WhatsApp Business HSMWhats App HSMComponent Get</a>, based on
+ * <a href="https://developers.facebook.com/docs/whatsapp/business-management-api/message-templates/components">
+ * Template Components</a>
+ */
 public class WhatsAppMessageTemplateComponent extends AbstractFacebookType {
 
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Component type.
+   */
   @Getter
   @Setter
   @Facebook
   private Type type;
 
+  /**
+   * Indicates media asset type for the component type
+   */
   @Getter
   @Setter
   @Facebook
   private Format format;
 
+  /**
+   * Component text. Required for components with type HEADER, BODY or FOOTER.
+   */
   @Getter
   @Setter
   @Facebook
   private String text;
 
+  /**
+   * Whether a security recommendation is included in the body text.
+   */
+  @Getter
+  @Setter
+  @Facebook("add_security_recommendation")
+  private Boolean addSecurityRecommendation;
+
+  /**
+   * The number of minutes that the authentication code will expire in. (minimum 1, maximum 90)
+   */
+  @Getter
+  @Setter
+  @Facebook("code_expiration_minutes")
+  private Integer codeExpirationMinutes;
+
+  /**
+   * The illustrative sample text for the parameter.
+   * Applies only if the component has parameters.
+   */
   @Getter
   @Setter
   @Facebook
-  private List<Button> buttons;
+  private Example example;
+
+  /**
+   * Button components to be used in the template.
+   */
+  @Getter
+  @Setter
+  @Facebook
+  private List<Button> buttons = new ArrayList<>();
 
   public enum Type {
     HEADER, BODY, FOOTER, BUTTONS
@@ -60,21 +106,30 @@ public class WhatsAppMessageTemplateComponent extends AbstractFacebookType {
   }
 
   public enum ButtonType {
-    QUICK_REPLY, URL, PHONE_NUMBER
+    QUICK_REPLY, URL, PHONE_NUMBER, COPY_CODE, FLOW, MPM, SPM
   }
 
   public static class Button {
 
+    /**
+     * Button type.
+     */
     @Getter
     @Setter
     @Facebook
     private ButtonType type;
 
+    /**
+     * Button label text.
+     */
     @Getter
     @Setter
     @Facebook
     private String text;
 
+    /**
+     * URL of website. Supports 1 variable.
+     */
     @Getter
     @Setter
     @Facebook
@@ -84,5 +139,95 @@ public class WhatsAppMessageTemplateComponent extends AbstractFacebookType {
     @Setter
     @Facebook("phone_number")
     private String phoneNumber;
+
+    /**
+     * Single element list with the strings to copy to the device's clipboard if the type is 'COPY_CODE',
+     * or sample URL if the type is 'URL' and has a parameter.
+     */
+    @Getter
+    @Setter
+    @Facebook
+    private List<String> example;
+
+    /**
+     * Unique identifier of the Flow provided by WhatsApp.
+     * The Flow must be published.
+     */
+    @Getter
+    @Setter
+    @Facebook("flow_id")
+    private String flowId;
+
+    /**
+     * The name of the Flow, supported in Cloud API only.
+     * Cannot be used with flow_id or flow_json.
+     */
+    @Getter
+    @Setter
+    @Facebook("flow_name")
+    private String flowName;
+
+    /**
+     * JSON string specifying the layout of the Flow.
+     * Cannot be used with flow_id or flow_name.
+     */
+    @Getter
+    @Setter
+    @Facebook("flow_json")
+    private String flowJson;
+
+    /**
+     * Action to define the Flow behavior.
+     * Can be 'navigate' for predefined screens or 'data_exchange' for dynamic screens.
+     */
+    @Getter
+    @Setter
+    @Facebook("flow_action")
+    private String flowAction;
+
+    /**
+     * ID of the entry screen in the Flow if flow_action is 'navigate'.
+     * Optional. Default is 'FIRST_ENTRY_SCREEN'.
+     */
+    @Getter
+    @Setter
+    @Facebook("navigate_screen")
+    private String navigateScreen;
+  }
+
+
+  public static class Example {
+    @Getter
+    @Setter
+    @Facebook("header_text")
+    private List<String> headerText = new ArrayList<>();
+
+    @Getter
+    @Setter
+    @Facebook("header_handle")
+    private List<String> headerHandle = new ArrayList<>();
+
+    @Getter
+    @Setter
+    @Facebook("body_text_named_params")
+    private List<NamedParam> bodyTextNamedParams = new ArrayList<>();
+
+    @Getter
+    @Setter
+    @Facebook("header_text_named_params")
+    private List<NamedParam> headerTextNamedParams = new ArrayList<>();
+  }
+
+  public static class NamedParam {
+
+    @Getter
+    @Setter
+    @Facebook("param_name")
+    private String paramName;
+
+    @Getter
+    @Setter
+    @Facebook
+    private String example;
   }
 }

--- a/src/test/java/com/restfb/types/whatsapp/WhatsAppMessageTemplateComponentTest.java
+++ b/src/test/java/com/restfb/types/whatsapp/WhatsAppMessageTemplateComponentTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2010-2025 Mark Allen, Norbert Bartels.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.restfb.types.whatsapp;
+
+import com.restfb.AbstractJsonMapperTests;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class WhatsAppMessageTemplateComponentTest extends AbstractJsonMapperTests {
+
+  @Test
+  void checkWhatsAppMessageTemplateComponents() {
+
+    List<WhatsAppMessageTemplateComponent> components = createJsonMapper().toJavaList(
+            jsonFromClasspath("whatsapp/message-template-components"),
+            WhatsAppMessageTemplateComponent.class);
+
+    assertNotNull(components);
+
+    // Test HEADER component with TEXT format
+    WhatsAppMessageTemplateComponent headerText = components.get(0);
+    assertEquals(WhatsAppMessageTemplateComponent.Type.HEADER, headerText.getType());
+    assertEquals(WhatsAppMessageTemplateComponent.Format.TEXT, headerText.getFormat());
+    assertEquals("Header text", headerText.getText());
+
+    // Test HEADER component with IMAGE format
+    WhatsAppMessageTemplateComponent headerImage = components.get(1);
+    assertEquals(WhatsAppMessageTemplateComponent.Type.HEADER, headerImage.getType());
+    assertEquals(WhatsAppMessageTemplateComponent.Format.IMAGE, headerImage.getFormat());
+    assertNotNull(headerImage.getExample());
+    assertEquals("https://example.com", headerImage.getExample().getHeaderHandle().get(0));
+
+    // Test HEADER component with numeric type parameters
+    WhatsAppMessageTemplateComponent headerNumericParams = components.get(2);
+    assertEquals(WhatsAppMessageTemplateComponent.Type.HEADER, headerNumericParams.getType());
+    assertEquals(WhatsAppMessageTemplateComponent.Format.TEXT, headerNumericParams.getFormat());
+    assertTrue(headerNumericParams.getText().contains("{{1}}"));
+    assertNotNull(headerNumericParams.getExample());
+    assertEquals("Albert", headerNumericParams.getExample().getHeaderText().get(0));
+
+    // Test HEADER component with named type parameters
+    WhatsAppMessageTemplateComponent headerNamedParams = components.get(3);
+    assertEquals(WhatsAppMessageTemplateComponent.Type.HEADER, headerNamedParams.getType());
+    assertEquals(WhatsAppMessageTemplateComponent.Format.TEXT, headerNamedParams.getFormat());
+    assertTrue(headerNamedParams.getText().contains("{{name}}"));
+    assertNotNull(headerNamedParams.getExample());
+    assertEquals("name", headerNamedParams.getExample().getHeaderTextNamedParams().get(0).getParamName());
+    assertEquals("Albert", headerNamedParams.getExample().getHeaderTextNamedParams().get(0).getExample());
+
+
+    // Test BODY component with named type parameters
+    WhatsAppMessageTemplateComponent bodyNamedParams = components.get(4);
+    assertEquals(WhatsAppMessageTemplateComponent.Type.BODY, bodyNamedParams.getType());
+    assertTrue(bodyNamedParams.getText().contains("{{name}}"));
+    assertNotNull(bodyNamedParams.getExample());
+    assertEquals("name", bodyNamedParams.getExample().getBodyTextNamedParams().get(0).getParamName());
+    assertEquals("Albert", bodyNamedParams.getExample().getBodyTextNamedParams().get(0).getExample());
+
+
+    // Test FOOTER component (with code expiration)
+    WhatsAppMessageTemplateComponent footer = components.get(5);
+    assertEquals(WhatsAppMessageTemplateComponent.Type.FOOTER, footer.getType());
+    assertEquals("This code expires in 10 minutes.", footer.getText());
+    assertEquals(10, footer.getCodeExpirationMinutes());
+
+
+    // Test BUTTONS component with URL button and one parameter
+    WhatsAppMessageTemplateComponent buttonUrl = components.get(6);
+    assertEquals(WhatsAppMessageTemplateComponent.Type.BUTTONS, buttonUrl.getType());
+    WhatsAppMessageTemplateComponent.Button urlButton = buttonUrl.getButtons().get(0);
+    assertEquals(WhatsAppMessageTemplateComponent.ButtonType.URL, urlButton.getType());
+    assertEquals("Copy code", urlButton.getText());
+    assertTrue(urlButton.getUrl().contains("{{1}}"));
+    assertNotNull(urlButton.getExample());
+    assertEquals("https://example.com/item", urlButton.getExample().get(0));
+
+    // Test BUTTONS component with COPY_CODE button
+    WhatsAppMessageTemplateComponent buttonCopyCode = components.get(7);
+    assertEquals(WhatsAppMessageTemplateComponent.Type.BUTTONS, buttonCopyCode.getType());
+    WhatsAppMessageTemplateComponent.Button copyCodeButton = buttonCopyCode.getButtons().get(0);
+    assertEquals(WhatsAppMessageTemplateComponent.ButtonType.COPY_CODE, copyCodeButton.getType());
+    assertEquals("Copy offer code", copyCodeButton.getText());
+    assertNotNull(copyCodeButton.getExample());
+    assertEquals("SALE2025", copyCodeButton.getExample().get(0));
+
+    // Test BUTTONS component with FLOW button
+    WhatsAppMessageTemplateComponent buttonFlow = components.get(8);
+    assertEquals(WhatsAppMessageTemplateComponent.Type.BUTTONS, buttonFlow.getType());
+    WhatsAppMessageTemplateComponent.Button flowButton = buttonFlow.getButtons().get(0);
+    assertEquals(WhatsAppMessageTemplateComponent.ButtonType.FLOW, flowButton.getType());
+    assertEquals("Flow button", flowButton.getText());
+    assertEquals("9999999999999999", flowButton.getFlowId());
+    assertEquals("NAVIGATE", flowButton.getFlowAction());
+    assertEquals("QUESTION_ONE", flowButton.getNavigateScreen());
+
+    // Test BUTTONS component with PHONE_NUMBER button
+    WhatsAppMessageTemplateComponent buttonPhone = components.get(9);
+    assertEquals(WhatsAppMessageTemplateComponent.Type.BUTTONS, buttonPhone.getType());
+    WhatsAppMessageTemplateComponent.Button phoneButton = buttonPhone.getButtons().get(0);
+    assertEquals(WhatsAppMessageTemplateComponent.ButtonType.PHONE_NUMBER, phoneButton.getType());
+    assertEquals("Call", phoneButton.getText());
+    assertEquals("+593999999999", phoneButton.getPhoneNumber());
+
+    // Test BUTTONS component with QUICK_REPLY button
+    WhatsAppMessageTemplateComponent buttonQuickReply = components.get(10);
+    assertEquals(WhatsAppMessageTemplateComponent.Type.BUTTONS, buttonQuickReply.getType());
+    WhatsAppMessageTemplateComponent.Button quickReplyButton = buttonQuickReply.getButtons().get(0);
+    assertEquals(WhatsAppMessageTemplateComponent.ButtonType.QUICK_REPLY, quickReplyButton.getType());
+    assertEquals("Quick reply text", quickReplyButton.getText());
+
+    // Test BUTTONS component with MPM button
+    WhatsAppMessageTemplateComponent buttonMpm = components.get(11);
+    assertEquals(WhatsAppMessageTemplateComponent.Type.BUTTONS, buttonMpm.getType());
+    WhatsAppMessageTemplateComponent.Button mpmButton = buttonMpm.getButtons().get(0);
+    assertEquals(WhatsAppMessageTemplateComponent.ButtonType.MPM, mpmButton.getType());
+    assertEquals("View items", mpmButton.getText());
+
+    // Test BUTTONS component with SPM button
+    WhatsAppMessageTemplateComponent buttonSpm = components.get(12);
+    assertEquals(WhatsAppMessageTemplateComponent.Type.BUTTONS, buttonSpm.getType());
+    WhatsAppMessageTemplateComponent.Button spmButton = buttonSpm.getButtons().get(0);
+    assertEquals(WhatsAppMessageTemplateComponent.ButtonType.SPM, spmButton.getType());
+    assertEquals("View", spmButton.getText());
+  }
+}

--- a/src/test/resources/json/whatsapp/message-template-components.json
+++ b/src/test/resources/json/whatsapp/message-template-components.json
@@ -1,0 +1,130 @@
+[
+  {
+    "type": "HEADER",
+    "format": "TEXT",
+    "text": "Header text"
+  },
+  {
+    "type": "HEADER",
+    "format": "IMAGE",
+    "example": {
+      "header_handle": [
+        "https://example.com"
+      ]
+    }
+  },
+  {
+    "type": "HEADER",
+    "format": "TEXT",
+    "text": "Hello {{1}}",
+    "example": {
+      "header_text": [
+        "Albert"
+      ]
+    }
+  },
+  {
+    "type": "HEADER",
+    "format": "TEXT",
+    "text": "Hello {{name}}",
+    "example": {
+      "header_text_named_params": [
+        {
+          "param_name": "name",
+          "example": "Albert"
+        }
+      ]
+    }
+  },
+  {
+    "type": "BODY",
+    "text": "Hello {{name}}",
+    "example": {
+      "body_text_named_params": [
+        {
+          "param_name": "name",
+          "example": "Albert"
+        }
+      ]
+    }
+  },
+  {
+    "type": "FOOTER",
+    "text": "This code expires in 10 minutes.",
+    "code_expiration_minutes": 10
+  },
+  {
+    "type": "BUTTONS",
+    "buttons": [
+      {
+        "type": "URL",
+        "text": "Copy code",
+        "url": "https://example.com/{{1}}",
+        "example": [
+          "https://example.com/item"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "BUTTONS",
+    "buttons": [
+      {
+        "type": "COPY_CODE",
+        "text": "Copy offer code",
+        "example": [
+          "SALE2025"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "BUTTONS",
+    "buttons": [
+      {
+        "type": "FLOW",
+        "text": "Flow button",
+        "flow_id": "9999999999999999",
+        "flow_action": "NAVIGATE",
+        "navigate_screen": "QUESTION_ONE"
+      }
+    ]
+  },
+  {
+    "type": "BUTTONS",
+    "buttons": [
+      {
+        "type": "PHONE_NUMBER",
+        "text": "Call",
+        "phone_number": "+593999999999"
+      }
+    ]
+  },
+  {
+    "type": "BUTTONS",
+    "buttons": [
+      {
+        "type": "QUICK_REPLY",
+        "text": "Quick reply text"
+      }
+    ]
+  },
+  {
+    "type": "BUTTONS",
+    "buttons": [
+      {
+        "type": "MPM",
+        "text": "View items"
+      }
+    ]
+  },
+  {
+    "type": "BUTTONS",
+    "buttons": [
+      {
+        "type": "SPM",
+        "text": "View"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This PR adds missing fields for `WhatsAppMessageTemplateComponent` Type, based on [Template Components](https://developers.facebook.com/docs/whatsapp/business-management-api/message-templates/components) documentation, and includes classes to map template parameters for the `BUTTONS` type component.