### PR TITLE
Add missing fields to `WhatsAppMessageTemplate` and `WhatsAppMessageTemplateComponent`

### DIFF
--- a/src/main/lombok/com/restfb/types/whatsapp/WhatsAppMessageTemplate.java
+++ b/src/main/lombok/com/restfb/types/whatsapp/WhatsAppMessageTemplate.java
@@ -92,4 +92,16 @@ public class WhatsAppMessageTemplate extends NamedFacebookType {
   @Setter
   @Facebook("quality_score")
   private WhatsAppHSMQualityScoreShape qualityScore;
+
+  /**
+   * The parameter format of the template
+   */
+  @Getter
+  @Setter
+  @Facebook("parameter_format")
+  private ParameterFormat parameterFormat;
+
+  public enum ParameterFormat {
+    NAMED, POSITIONAL
+  }
 }

--- a/src/main/lombok/com/restfb/types/whatsapp/WhatsAppMessageTemplateComponent.java
+++ b/src/main/lombok/com/restfb/types/whatsapp/WhatsAppMessageTemplateComponent.java
@@ -209,6 +209,11 @@ public class WhatsAppMessageTemplateComponent extends AbstractFacebookType {
 
     @Getter
     @Setter
+    @Facebook("body_text")
+    private List<List<String>> bodyText = new ArrayList<>();
+
+    @Getter
+    @Setter
     @Facebook("body_text_named_params")
     private List<NamedParam> bodyTextNamedParams = new ArrayList<>();
 

--- a/src/test/java/com/restfb/types/whatsapp/WhatsAppMessageTemplateComponentTest.java
+++ b/src/test/java/com/restfb/types/whatsapp/WhatsAppMessageTemplateComponentTest.java
@@ -143,5 +143,14 @@ public class WhatsAppMessageTemplateComponentTest extends AbstractJsonMapperTest
     WhatsAppMessageTemplateComponent.Button spmButton = buttonSpm.getButtons().get(0);
     assertEquals(WhatsAppMessageTemplateComponent.ButtonType.SPM, spmButton.getType());
     assertEquals("View", spmButton.getText());
+
+
+    // Test BODY component with positional type parameters
+    WhatsAppMessageTemplateComponent bodyPositionalParams = components.get(13);
+    assertEquals(WhatsAppMessageTemplateComponent.Type.BODY, bodyPositionalParams.getType());
+    assertTrue(bodyPositionalParams.getText().contains("{{1}}"));
+    assertEquals(1, bodyPositionalParams.getExample().getBodyText().size());
+    assertEquals(1, bodyPositionalParams.getExample().getBodyText().get(0).size());
+    assertEquals("Albert", bodyPositionalParams.getExample().getBodyText().get(0).get(0));
   }
 }

--- a/src/test/resources/json/whatsapp/message-template-components.json
+++ b/src/test/resources/json/whatsapp/message-template-components.json
@@ -126,5 +126,16 @@
         "text": "View"
       }
     ]
+  },
+  {
+    "type": "BODY",
+    "text": "Hello {{1}}",
+    "example": {
+      "body_text": [
+        [
+          "Albert"
+        ]
+      ]
+    }
   }
 ]


### PR DESCRIPTION
This PR adds missing fields to the following types:

- `WhatsAppMessageTemplate`: Added `parameterFormat` to specify the type of parameters.
- `WhatsAppMessageTemplateComponent`: Added `bodyText` in the embedded `Example` type to map values when the template’s body or header contains positional parameters.