### PR TITLE
feat(whatsapp): support BSUID webhook payloads

### DIFF
--- a/src/main/lombok/com/restfb/types/webhook/ChangeValueFactory.java
+++ b/src/main/lombok/com/restfb/types/webhook/ChangeValueFactory.java
@@ -190,8 +190,10 @@ public class ChangeValueFactory {
     PHONE_NUMBER_QUALITY_UPDATE(PhoneNumberQualityUpdateValue.class), //
     ACCOUNT_UPDATE(AccountUpdateValue.class), //
     ACCOUNT_REVIEW_UPDATE(AccountReviewUpdateValue.class),//
+    BUSINESS_USERNAME_UPDATE(BusinessUsernameUpdateValue.class), //
 
     // Whatsapp Business Platform
+    USER_ID_UPDATE_WHATSAPP(UserIdUpdateValue.class), //
     MESSAGES_WHATSAPP(WhatsappMessagesValue.class);
 
     private Class<ChangeValue> valueClass;

--- a/src/main/lombok/com/restfb/types/webhook/whatsapp/BusinessUsernameUpdateValue.java
+++ b/src/main/lombok/com/restfb/types/webhook/whatsapp/BusinessUsernameUpdateValue.java
@@ -19,34 +19,23 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.restfb.types.whatsapp.platform.status;
+package com.restfb.types.webhook.whatsapp;
 
 import com.restfb.Facebook;
-import com.restfb.types.AbstractFacebookType;
 
 import lombok.Getter;
-import lombok.Setter;
 
-public class Pricing extends AbstractFacebookType {
-
-  @Getter
-  @Setter
-  @Facebook("pricing_model")
-  private String pricingModel;
+public class BusinessUsernameUpdateValue extends AbstractWhatsappBaseChangeValue {
 
   @Getter
-  @Setter
+  @Facebook("display_phone_number")
+  private String displayPhoneNumber;
+
+  @Getter
   @Facebook
-  private boolean billable;
+  private String username;
 
   @Getter
-  @Setter
   @Facebook
-  private CategoryType category;
-
-  @Getter
-  @Setter
-  @Facebook
-  private String type;
-
+  private String status;
 }

--- a/src/main/lombok/com/restfb/types/webhook/whatsapp/UserIdUpdateValue.java
+++ b/src/main/lombok/com/restfb/types/webhook/whatsapp/UserIdUpdateValue.java
@@ -19,34 +19,67 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.restfb.types.whatsapp.platform.status;
+package com.restfb.types.webhook.whatsapp;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 import com.restfb.Facebook;
-import com.restfb.types.AbstractFacebookType;
+import com.restfb.types.whatsapp.platform.Metadata;
+import com.restfb.types.whatsapp.platform.message.Contact;
 
 import lombok.Getter;
-import lombok.Setter;
 
-public class Pricing extends AbstractFacebookType {
-
-  @Getter
-  @Setter
-  @Facebook("pricing_model")
-  private String pricingModel;
+public class UserIdUpdateValue extends AbstractWhatsappBaseChangeValue {
 
   @Getter
-  @Setter
+  @Facebook("messaging_product")
+  private String messagingProduct;
+
+  @Getter
   @Facebook
-  private boolean billable;
+  private Metadata metadata;
 
   @Getter
-  @Setter
   @Facebook
-  private CategoryType category;
+  private List<Contact> contacts = new ArrayList<>();
 
   @Getter
-  @Setter
-  @Facebook
-  private String type;
+  @Facebook("user_id_update")
+  private List<UserIdUpdateItem> userIdUpdate = new ArrayList<>();
 
+  public static class UserIdUpdateItem {
+
+    @Getter
+    @Facebook("wa_id")
+    private String waId;
+
+    @Getter
+    @Facebook
+    private String detail;
+
+    @Getter
+    @Facebook("user_id")
+    private ChangedId userId;
+
+    @Getter
+    @Facebook("parent_user_id")
+    private ChangedId parentUserId;
+
+    @Getter
+    @Facebook
+    private Date timestamp;
+  }
+
+  public static class ChangedId {
+
+    @Getter
+    @Facebook
+    private String previous;
+
+    @Getter
+    @Facebook
+    private String current;
+  }
 }

--- a/src/main/lombok/com/restfb/types/whatsapp/platform/Message.java
+++ b/src/main/lombok/com/restfb/types/whatsapp/platform/Message.java
@@ -71,6 +71,16 @@ public class Message extends AbstractFacebookType {
 
   @Getter
   @Setter
+  @Facebook("from_user_id")
+  private String fromUserId;
+
+  @Getter
+  @Setter
+  @Facebook("from_parent_user_id")
+  private String fromParentUserId;
+
+  @Getter
+  @Setter
   @Facebook
   private String id;
 
@@ -98,6 +108,11 @@ public class Message extends AbstractFacebookType {
   @Setter
   @Facebook
   private Referral referral;
+
+  @Getter
+  @Setter
+  @Facebook
+  private String origin;
 
   @Getter
   @Setter
@@ -138,6 +153,11 @@ public class Message extends AbstractFacebookType {
   @Setter
   @Facebook
   private List<MessageContact> contacts = new ArrayList<>();
+
+  @Getter
+  @Setter
+  @Facebook("group_id")
+  private String groupId;
 
   /**
    * An arbitrary 256B string, useful for tracking (optional).

--- a/src/main/lombok/com/restfb/types/whatsapp/platform/Profile.java
+++ b/src/main/lombok/com/restfb/types/whatsapp/platform/Profile.java
@@ -33,4 +33,9 @@ public class Profile extends AbstractFacebookType {
   @Setter
   @Facebook
   private String name;
+
+  @Getter
+  @Setter
+  @Facebook
+  private String username;
 }

--- a/src/main/lombok/com/restfb/types/whatsapp/platform/Status.java
+++ b/src/main/lombok/com/restfb/types/whatsapp/platform/Status.java
@@ -60,6 +60,31 @@ public class Status extends AbstractFacebookType {
 
   @Getter
   @Setter
+  @Facebook("recipient_user_id")
+  private String recipientUserId;
+
+  @Getter
+  @Setter
+  @Facebook("parent_recipient_user_id")
+  private String parentRecipientUserId;
+
+  @Getter
+  @Setter
+  @Facebook("recipient_participant_id")
+  private String recipientParticipantId;
+
+  @Getter
+  @Setter
+  @Facebook("recipient_participant_user_id")
+  private String recipientParticipantUserId;
+
+  @Getter
+  @Setter
+  @Facebook("recipient_participant_parent_user_id")
+  private String recipientParticipantParentUserId;
+
+  @Getter
+  @Setter
   @Facebook
   private StatusType status;
 

--- a/src/main/lombok/com/restfb/types/whatsapp/platform/message/Contact.java
+++ b/src/main/lombok/com/restfb/types/whatsapp/platform/message/Contact.java
@@ -37,6 +37,16 @@ public class Contact extends AbstractFacebookType {
 
   @Getter
   @Setter
+  @Facebook("user_id")
+  private String userId;
+
+  @Getter
+  @Setter
+  @Facebook("parent_user_id")
+  private String parentUserId;
+
+  @Getter
+  @Setter
   @Facebook
   private Profile profile;
 }

--- a/src/main/lombok/com/restfb/types/whatsapp/platform/message/MessageContact.java
+++ b/src/main/lombok/com/restfb/types/whatsapp/platform/message/MessageContact.java
@@ -44,6 +44,11 @@ public class MessageContact extends AbstractFacebookType {
   @Getter
   @Setter
   @Facebook
+  private String vcard;
+
+  @Getter
+  @Setter
+  @Facebook
   private List<ContactPhone> phones;
 
   public static class ContactName extends AbstractFacebookType {

--- a/src/main/lombok/com/restfb/types/whatsapp/platform/message/System.java
+++ b/src/main/lombok/com/restfb/types/whatsapp/platform/message/System.java
@@ -63,6 +63,22 @@ public class System extends AbstractFacebookType {
   private String waId;
 
   /**
+   * New business-scoped user ID for the customer when their phone number is updated.
+   */
+  @Getter
+  @Setter
+  @Facebook("user_id")
+  private String userId;
+
+  /**
+   * New parent business-scoped user ID for the customer when their phone number is updated.
+   */
+  @Getter
+  @Setter
+  @Facebook("parent_user_id")
+  private String parentUserId;
+
+  /**
    * Type of system update.
    */
   @Getter

--- a/src/test/java/com/restfb/types/WebhookWhatsappTest.java
+++ b/src/test/java/com/restfb/types/WebhookWhatsappTest.java
@@ -31,6 +31,8 @@ import com.restfb.types.webhook.WebhookEntry;
 import com.restfb.types.webhook.WebhookObject;
 import com.restfb.types.webhook.whatsapp.*;
 import com.restfb.types.whatsapp.platform.Message;
+import com.restfb.types.whatsapp.platform.Status;
+import com.restfb.types.whatsapp.platform.message.Contact;
 import com.restfb.types.whatsapp.platform.message.Error;
 import com.restfb.types.whatsapp.platform.message.MessageContact;
 import com.restfb.types.whatsapp.platform.message.MessageType;
@@ -106,6 +108,34 @@ class WebhookWhatsappTest extends AbstractJsonMapperTests {
   }
 
   @Test
+  void businessUsernameUpdateApproved() {
+    BusinessUsernameUpdateValue change =
+        getWHObjectFromJson("webhook-businessUsernameUpdate-approved", BusinessUsernameUpdateValue.class);
+    assertThat(change.getDisplayPhoneNumber()).isEqualTo("15550783881");
+    assertThat(change.getUsername()).isEqualTo("acme_support");
+    assertThat(change.getStatus()).isEqualTo("approved");
+  }
+
+  @Test
+  void userIdUpdate() {
+    UserIdUpdateValue change = getWHObjectFromJson("webhook-userIdUpdate", UserIdUpdateValue.class);
+    assertThat(change.getMessagingProduct()).isEqualTo("whatsapp");
+    assertThat(change.getContacts()).hasSize(1);
+    assertThat(change.getContacts().get(0).getWaId()).isEqualTo("16505551234");
+    assertThat(change.getUserIdUpdate()).hasSize(1);
+    UserIdUpdateValue.UserIdUpdateItem update = change.getUserIdUpdate().get(0);
+    assertThat(update.getWaId()).isEqualTo("16505551234");
+    assertThat(update.getDetail()).isEqualTo("User id for Sheena Nelson has been updated.");
+    assertThat(update.getUserId()).isNotNull();
+    assertThat(update.getUserId().getPrevious()).isEqualTo("US.10101010101010101010");
+    assertThat(update.getUserId().getCurrent()).isEqualTo("US.13491208655302741918");
+    assertThat(update.getParentUserId()).isNotNull();
+    assertThat(update.getParentUserId().getPrevious()).isEqualTo("US.ENT.10101010101010101010");
+    assertThat(update.getParentUserId().getCurrent()).isEqualTo("US.ENT.11815799212886844830");
+    assertThat(update.getTimestamp()).isNotNull();
+  }
+
+  @Test
   void messageContacts() {
     WhatsappMessagesValue messagesValue =
         getWHObjectFromJson("webhook-incoming-message-contacts", WhatsappMessagesValue.class);
@@ -163,6 +193,101 @@ class WebhookWhatsappTest extends AbstractJsonMapperTests {
     assertThat(message.getErrors()).hasSize(1);
     Error error = message.getErrors().get(0);
     assertThat(error.getErrorData()).isNotNull();
+  }
+
+  @Test
+  void incomingMessageWithBsuidFields() {
+    WhatsappMessagesValue messagesValue =
+        getWHObjectFromJson("webhook-incoming-message-text-bsuid", WhatsappMessagesValue.class);
+    assertThat(messagesValue.getContacts()).hasSize(1);
+    Contact contact = messagesValue.getContacts().get(0);
+    assertThat(contact.getWaId()).isNull();
+    assertThat(contact.getUserId()).isEqualTo("US.13491208655302741918");
+    assertThat(contact.getParentUserId()).isEqualTo("US.ENT.11815799212886844830");
+    assertThat(contact.getProfile()).isNotNull();
+    assertThat(contact.getProfile().getName()).isEqualTo("Sheena Nelson");
+    assertThat(contact.getProfile().getUsername()).isEqualTo("@realsheenanelson");
+
+    assertThat(messagesValue.getMessages()).hasSize(1);
+    Message message = messagesValue.getMessages().get(0);
+    assertThat(message.getFrom()).isNull();
+    assertThat(message.getFromUserId()).isEqualTo("US.13491208655302741918");
+    assertThat(message.getFromParentUserId()).isEqualTo("US.ENT.11815799212886844830");
+    assertThat(message.getGroupId()).isEqualTo("120363418770915618@g.us");
+    assertThat(message.getType()).isEqualTo(MessageType.text);
+    assertThat(message.getText()).isNotNull();
+    assertThat(message.getText().getBody()).isEqualTo("Does it come in another color?");
+  }
+
+  @Test
+  void statusMessageWithBsuidFields() {
+    WhatsappMessagesValue messagesValue =
+        getWHObjectFromJson("webhook-incoming-message-status-bsuid", WhatsappMessagesValue.class);
+    assertThat(messagesValue.getContacts()).hasSize(1);
+    Contact contact = messagesValue.getContacts().get(0);
+    assertThat(contact.getWaId()).isNull();
+    assertThat(contact.getUserId()).isEqualTo("US.13491208655302741918");
+    assertThat(contact.getParentUserId()).isEqualTo("US.ENT.11815799212886844830");
+    assertThat(contact.getProfile()).isNotNull();
+    assertThat(contact.getProfile().getName()).isEqualTo("Pablo M.");
+    assertThat(contact.getProfile().getUsername()).isEqualTo("@pablomorales");
+
+    assertThat(messagesValue.getStatuses()).hasSize(1);
+    Status status = messagesValue.getStatuses().get(0);
+    assertThat(status.getRecipientId()).isNull();
+    assertThat(status.getRecipientUserId()).isEqualTo("US.13491208655302741918");
+    assertThat(status.getParentRecipientUserId()).isEqualTo("US.ENT.11815799212886844830");
+    assertThat(status.getPricing()).isNotNull();
+    assertThat(status.getPricing().getType()).isEqualTo("regular");
+  }
+
+  @Test
+  void groupStatusMessageWithBsuidFields() {
+    WhatsappMessagesValue messagesValue =
+        getWHObjectFromJson("webhook-incoming-message-status-group-bsuid", WhatsappMessagesValue.class);
+    assertThat(messagesValue.getStatuses()).hasSize(1);
+    Status status = messagesValue.getStatuses().get(0);
+    assertThat(status.getRecipientId()).isEqualTo("120363418770915618@g.us");
+    assertThat(status.getRecipientParticipantId()).isEqualTo("16505551234");
+    assertThat(status.getRecipientParticipantUserId()).isEqualTo("US.13491208655302741918");
+    assertThat(status.getRecipientParticipantParentUserId()).isEqualTo("US.ENT.11815799212886844830");
+  }
+
+  @Test
+  void systemMessageWithBsuidFields() {
+    WhatsappMessagesValue messagesValue =
+        getWHObjectFromJson("webhook-incoming-message-system-bsuid", WhatsappMessagesValue.class);
+    assertThat(messagesValue.getMessages()).hasSize(1);
+    Message message = messagesValue.getMessages().get(0);
+    assertThat(message.isSystem()).isTrue();
+    assertThat(message.getSystem().getWaId()).isNull();
+    assertThat(message.getSystem().getUserId()).isEqualTo("US.13491208655302741918");
+    assertThat(message.getSystem().getParentUserId()).isEqualTo("US.ENT.11815799212886844830");
+    assertThat(message.getSystem().getType()).isEqualTo("user_changed_user_id");
+    assertThat(message.getSystem().getBody())
+        .isEqualTo("User Sheena Nelson changed from US.10101010101010101010 to US.13491208655302741918");
+  }
+
+  @Test
+  void contactsRequestMessageWithBsuidFields() {
+    WhatsappMessagesValue messagesValue =
+        getWHObjectFromJson("webhook-incoming-message-contacts-request-bsuid", WhatsappMessagesValue.class);
+    assertThat(messagesValue.getContacts()).hasSize(1);
+    Contact contact = messagesValue.getContacts().get(0);
+    assertThat(contact.getUserId()).isEqualTo("US.13491208655302741918");
+    assertThat(contact.getParentUserId()).isEqualTo("US.ENT.11815799212886844830");
+    assertThat(contact.getProfile()).isNotNull();
+    assertThat(contact.getProfile().getUsername()).isEqualTo("@realsheenanelson");
+
+    assertThat(messagesValue.getMessages()).hasSize(1);
+    Message message = messagesValue.getMessages().get(0);
+    assertThat(message.getType()).isEqualTo(MessageType.contacts);
+    assertThat(message.getOrigin()).isEqualTo("contact_request/other");
+    assertThat(message.getContacts()).hasSize(1);
+    MessageContact messageContact = message.getContacts().get(0);
+    assertThat(messageContact.getVcard()).contains("BEGIN:VCARD");
+    assertThat(messageContact.getPhones()).hasSize(1);
+    assertThat(messageContact.getPhones().get(0).getPhone()).isEqualTo("15551234567");
   }
 
   private <T extends ChangeValue> T getWHObjectFromJson(String jsonName, Class<T> clazz) {

--- a/src/test/resources/json/whatsapp/webhook-businessUsernameUpdate-approved.json
+++ b/src/test/resources/json/whatsapp/webhook-businessUsernameUpdate-approved.json
@@ -1,0 +1,19 @@
+{
+  "object": "whatsapp_business_account",
+  "entry": [
+    {
+      "id": "102290129340398",
+      "time": 1749416383,
+      "changes": [
+        {
+          "field": "business_username_update",
+          "value": {
+            "display_phone_number": "15550783881",
+            "username": "acme_support",
+            "status": "approved"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/json/whatsapp/webhook-incoming-message-contacts-request-bsuid.json
+++ b/src/test/resources/json/whatsapp/webhook-incoming-message-contacts-request-bsuid.json
@@ -1,0 +1,48 @@
+{
+  "object": "whatsapp_business_account",
+  "entry": [
+    {
+      "id": "102290129340398",
+      "changes": [
+        {
+          "value": {
+            "messaging_product": "whatsapp",
+            "metadata": {
+              "display_phone_number": "15550783881",
+              "phone_number_id": "106540352242922"
+            },
+            "contacts": [
+              {
+                "profile": {
+                  "name": "Sheena Nelson",
+                  "username": "@realsheenanelson"
+                },
+                "user_id": "US.13491208655302741918",
+                "parent_user_id": "US.ENT.11815799212886844830"
+              }
+            ],
+            "messages": [
+              {
+                "id": "wamid.HBgLMTY1MDM4Nzk0MzkVAgASGBQzQTRBNjU5OUFFRTAzODEwMTQ0RgA=",
+                "timestamp": "1749416383",
+                "type": "contacts",
+                "origin": "contact_request/other",
+                "contacts": [
+                  {
+                    "vcard": "BEGIN:VCARD\nVERSION:3.0\nFN:Sheena Nelson\nTEL;TYPE=CELL:15551234567\nEND:VCARD",
+                    "phones": [
+                      {
+                        "phone": "15551234567"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "field": "messages"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/json/whatsapp/webhook-incoming-message-status-bsuid.json
+++ b/src/test/resources/json/whatsapp/webhook-incoming-message-status-bsuid.json
@@ -1,0 +1,45 @@
+{
+  "object": "whatsapp_business_account",
+  "entry": [
+    {
+      "id": "102290129340398",
+      "changes": [
+        {
+          "value": {
+            "messaging_product": "whatsapp",
+            "metadata": {
+              "display_phone_number": "15550783881",
+              "phone_number_id": "106540352242922"
+            },
+            "contacts": [
+              {
+                "profile": {
+                  "name": "Pablo M.",
+                  "username": "@pablomorales"
+                },
+                "user_id": "US.13491208655302741918",
+                "parent_user_id": "US.ENT.11815799212886844830"
+              }
+            ],
+            "statuses": [
+              {
+                "id": "wamid.HBgLMTY1MDM4Nzk0MzkVAgASGBQzQUFERjg0NDEzNDdFODU3MUMxMAA=",
+                "status": "delivered",
+                "timestamp": "1750030073",
+                "recipient_user_id": "US.13491208655302741918",
+                "parent_recipient_user_id": "US.ENT.11815799212886844830",
+                "pricing": {
+                  "billable": true,
+                  "pricing_model": "PMP",
+                  "type": "regular",
+                  "category": "marketing"
+                }
+              }
+            ]
+          },
+          "field": "messages"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/json/whatsapp/webhook-incoming-message-status-group-bsuid.json
+++ b/src/test/resources/json/whatsapp/webhook-incoming-message-status-group-bsuid.json
@@ -1,0 +1,31 @@
+{
+  "object": "whatsapp_business_account",
+  "entry": [
+    {
+      "id": "102290129340398",
+      "changes": [
+        {
+          "value": {
+            "messaging_product": "whatsapp",
+            "metadata": {
+              "display_phone_number": "15550783881",
+              "phone_number_id": "106540352242922"
+            },
+            "statuses": [
+              {
+                "id": "wamid.HBgLMTY1MDM4Nzk0MzkVAgASGBQzQUFERjg0NDEzNDdFODU3MUMxMAA=",
+                "status": "read",
+                "timestamp": "1750030173",
+                "recipient_id": "120363418770915618@g.us",
+                "recipient_participant_id": "16505551234",
+                "recipient_participant_user_id": "US.13491208655302741918",
+                "recipient_participant_parent_user_id": "US.ENT.11815799212886844830"
+              }
+            ]
+          },
+          "field": "messages"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/json/whatsapp/webhook-incoming-message-system-bsuid.json
+++ b/src/test/resources/json/whatsapp/webhook-incoming-message-system-bsuid.json
@@ -1,0 +1,33 @@
+{
+  "object": "whatsapp_business_account",
+  "entry": [
+    {
+      "id": "102290129340398",
+      "changes": [
+        {
+          "value": {
+            "messaging_product": "whatsapp",
+            "metadata": {
+              "display_phone_number": "15550783881",
+              "phone_number_id": "106540352242922"
+            },
+            "messages": [
+              {
+                "id": "wamid.HBgLMTY1MDM4Nzk0MzkVAgASGBQzQTRBNjU5OUFFRTAzODEwMTQ0RgA=",
+                "timestamp": "1749416383",
+                "type": "system",
+                "system": {
+                  "body": "User Sheena Nelson changed from US.10101010101010101010 to US.13491208655302741918",
+                  "user_id": "US.13491208655302741918",
+                  "parent_user_id": "US.ENT.11815799212886844830",
+                  "type": "user_changed_user_id"
+                }
+              }
+            ]
+          },
+          "field": "messages"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/json/whatsapp/webhook-incoming-message-text-bsuid.json
+++ b/src/test/resources/json/whatsapp/webhook-incoming-message-text-bsuid.json
@@ -1,0 +1,43 @@
+{
+  "object": "whatsapp_business_account",
+  "entry": [
+    {
+      "id": "102290129340398",
+      "changes": [
+        {
+          "value": {
+            "messaging_product": "whatsapp",
+            "metadata": {
+              "display_phone_number": "15550783881",
+              "phone_number_id": "106540352242922"
+            },
+            "contacts": [
+              {
+                "profile": {
+                  "name": "Sheena Nelson",
+                  "username": "@realsheenanelson"
+                },
+                "user_id": "US.13491208655302741918",
+                "parent_user_id": "US.ENT.11815799212886844830"
+              }
+            ],
+            "messages": [
+              {
+                "from_user_id": "US.13491208655302741918",
+                "from_parent_user_id": "US.ENT.11815799212886844830",
+                "group_id": "120363418770915618@g.us",
+                "id": "wamid.HBgLMTY1MDM4Nzk0MzkVAgASGBQzQTRBNjU5OUFFRTAzODEwMTQ0RgA=",
+                "timestamp": "1749416383",
+                "type": "text",
+                "text": {
+                  "body": "Does it come in another color?"
+                }
+              }
+            ]
+          },
+          "field": "messages"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/json/whatsapp/webhook-userIdUpdate.json
+++ b/src/test/resources/json/whatsapp/webhook-userIdUpdate.json
@@ -1,0 +1,43 @@
+{
+  "object": "whatsapp_business_account",
+  "entry": [
+    {
+      "id": "102290129340398",
+      "changes": [
+        {
+          "value": {
+            "messaging_product": "whatsapp",
+            "metadata": {
+              "display_phone_number": "15550783881",
+              "phone_number_id": "106540352242922"
+            },
+            "contacts": [
+              {
+                "profile": {
+                  "name": "Sheena Nelson"
+                },
+                "wa_id": "16505551234"
+              }
+            ],
+            "user_id_update": [
+              {
+                "wa_id": "16505551234",
+                "detail": "User id for Sheena Nelson has been updated.",
+                "user_id": {
+                  "previous": "US.10101010101010101010",
+                  "current": "US.13491208655302741918"
+                },
+                "parent_user_id": {
+                  "previous": "US.ENT.10101010101010101010",
+                  "current": "US.ENT.11815799212886844830"
+                },
+                "timestamp": "1749416383"
+              }
+            ]
+          },
+          "field": "user_id_update"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add conservative BSUID and username webhook field support for WhatsApp message, status, system, contact-request, and pricing payloads
- add `business_username_update` and `user_id_update` webhook value mappings in `ChangeValueFactory` with dedicated change value classes
- extend `WebhookWhatsappTest` with resource-based JSON fixtures for the new webhook payload shapes and optional-field cases

## Verification
- mvn -Dtest=WebhookWhatsappTest test
- mvn test

## Related
- Closes #1645