### PR TITLE
feat(whatsapp): support BSUID send targets

### DIFF
--- a/src/main/lombok/com/restfb/types/whatsapp/platform/SendMessage.java
+++ b/src/main/lombok/com/restfb/types/whatsapp/platform/SendMessage.java
@@ -41,6 +41,11 @@ public class SendMessage extends AbstractFacebookType {
   @Getter
   @Setter
   @Facebook
+  private String recipient;
+
+  @Getter
+  @Setter
+  @Facebook
   private Context context;
 
   @Getter
@@ -82,8 +87,27 @@ public class SendMessage extends AbstractFacebookType {
   @Facebook("messaging_product")
   private final String messagingProduct = "whatsapp";
 
+  public SendMessage() {
+  }
+
   public SendMessage(String to) {
     setTo(to);
+  }
+
+  public static SendMessage toPhone(String to) {
+    return new SendMessage(to);
+  }
+
+  public static SendMessage toRecipient(String recipient) {
+    SendMessage sendMessage = new SendMessage();
+    sendMessage.setRecipient(recipient);
+    return sendMessage;
+  }
+
+  public static SendMessage toPhoneAndRecipient(String to, String recipient) {
+    SendMessage sendMessage = new SendMessage(to);
+    sendMessage.setRecipient(recipient);
+    return sendMessage;
   }
 
   public void setReaction(Reaction reaction) {

--- a/src/main/lombok/com/restfb/types/whatsapp/platform/SuccessfulResponse.java
+++ b/src/main/lombok/com/restfb/types/whatsapp/platform/SuccessfulResponse.java
@@ -71,5 +71,10 @@ public class SuccessfulResponse extends AbstractFacebookType {
     @Setter
     @Facebook("wa_id")
     private String waId;
+
+    @Getter
+    @Setter
+    @Facebook("user_id")
+    private String userId;
   }
 }

--- a/src/test/java/com/restfb/types/whatsapp/platform/SendMessageJsonTest.java
+++ b/src/test/java/com/restfb/types/whatsapp/platform/SendMessageJsonTest.java
@@ -23,6 +23,7 @@ package com.restfb.types.whatsapp.platform;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 
@@ -41,5 +42,31 @@ class SendMessageJsonTest extends AbstractJsonMapperTests {
     assertEquals("wamid.foobar", response.getMessages().get(0).getId());
     assertEquals("123456789", response.getContacts().get(0).getInput());
     assertEquals("123456789", response.getContacts().get(0).getWaId());
+  }
+
+  @Test
+  void checkSuccessfulResponseWithBsuid() {
+    SuccessfulResponse response =
+        createJsonMapper().toJavaObject(jsonFromClasspath("whatsapp/message-response-bsuid"), SuccessfulResponse.class);
+    assertNotNull(response);
+    assertEquals("whatsapp", response.getMessagingProduct());
+    assertEquals(1, response.getContacts().size());
+    assertEquals(1, response.getMessages().size());
+    assertEquals("wamid.foobar", response.getMessages().get(0).getId());
+    assertEquals("US.13491208655302741918", response.getContacts().get(0).getInput());
+    assertNull(response.getContacts().get(0).getWaId());
+    assertEquals("US.13491208655302741918", response.getContacts().get(0).getUserId());
+  }
+
+  @Test
+  void checkSuccessfulResponseWithPhonePrecedence() {
+    SuccessfulResponse response = createJsonMapper().toJavaObject(
+        jsonFromClasspath("whatsapp/message-response-phone-precedence"), SuccessfulResponse.class);
+    assertNotNull(response);
+    assertEquals("whatsapp", response.getMessagingProduct());
+    assertEquals(1, response.getContacts().size());
+    assertEquals("+16505551234", response.getContacts().get(0).getInput());
+    assertEquals("16505551234", response.getContacts().get(0).getWaId());
+    assertNull(response.getContacts().get(0).getUserId());
   }
 }

--- a/src/test/java/com/restfb/types/whatsapp/platform/SendMessageTest.java
+++ b/src/test/java/com/restfb/types/whatsapp/platform/SendMessageTest.java
@@ -27,6 +27,7 @@ import java.util.Date;
 
 import org.junit.jupiter.api.Test;
 
+import com.restfb.AbstractJsonMapperTests;
 import com.restfb.DefaultJsonMapper;
 import com.restfb.JsonMapper;
 import com.restfb.testutils.AssertJson;
@@ -34,7 +35,7 @@ import com.restfb.types.whatsapp.platform.send.*;
 import com.restfb.types.whatsapp.platform.send.contact.*;
 import com.restfb.types.whatsapp.platform.send.interactive.*;
 
-class SendMessageTest {
+class SendMessageTest extends AbstractJsonMapperTests {
 
   @Test
   void checkReaction() {
@@ -61,6 +62,39 @@ class SendMessageTest {
     AssertJson.assertEquals(
       "{\"to\":\"12345678\",\"image\":{\"link\":\"https://restfb.com/img/favicon.png\"},\"type\":\"image\",\"messaging_product\":\"whatsapp\"}",
       mappedMessage);
+  }
+
+  @Test
+  void checkPhoneFactory() {
+    SendMessage message = SendMessage.toPhone("+16505551234");
+    message.setText(new Text("hello via phone"));
+
+    JsonMapper mapper = new DefaultJsonMapper();
+    String mappedMessage = mapper.toJson(message, true);
+
+    AssertJson.assertEquals(jsonFromClasspath("whatsapp/send-message-phone-only"), mappedMessage);
+  }
+
+  @Test
+  void checkRecipientFactory() {
+    SendMessage message = SendMessage.toRecipient("US.13491208655302741918");
+    message.setText(new Text("hello via bsuid"));
+
+    JsonMapper mapper = new DefaultJsonMapper();
+    String mappedMessage = mapper.toJson(message, true);
+
+    AssertJson.assertEquals(jsonFromClasspath("whatsapp/send-message-recipient-only"), mappedMessage);
+  }
+
+  @Test
+  void checkPhoneAndRecipientFactory() {
+    SendMessage message = SendMessage.toPhoneAndRecipient("+16505551234", "US.13491208655302741918");
+    message.setText(new Text("hello with fallback"));
+
+    JsonMapper mapper = new DefaultJsonMapper();
+    String mappedMessage = mapper.toJson(message, true);
+
+    AssertJson.assertEquals(jsonFromClasspath("whatsapp/send-message-to-and-recipient"), mappedMessage);
   }
 
   @Test

--- a/src/test/resources/json/whatsapp/message-response-bsuid.json
+++ b/src/test/resources/json/whatsapp/message-response-bsuid.json
@@ -1,0 +1,14 @@
+{
+  "messaging_product": "whatsapp",
+  "contacts": [
+    {
+      "input": "US.13491208655302741918",
+      "user_id": "US.13491208655302741918"
+    }
+  ],
+  "messages": [
+    {
+      "id": "wamid.foobar"
+    }
+  ]
+}

--- a/src/test/resources/json/whatsapp/message-response-phone-precedence.json
+++ b/src/test/resources/json/whatsapp/message-response-phone-precedence.json
@@ -1,0 +1,14 @@
+{
+  "messaging_product": "whatsapp",
+  "contacts": [
+    {
+      "input": "+16505551234",
+      "wa_id": "16505551234"
+    }
+  ],
+  "messages": [
+    {
+      "id": "wamid.foobar"
+    }
+  ]
+}

--- a/src/test/resources/json/whatsapp/send-message-phone-only.json
+++ b/src/test/resources/json/whatsapp/send-message-phone-only.json
@@ -1,0 +1,8 @@
+{
+  "to": "+16505551234",
+  "text": {
+    "body": "hello via phone"
+  },
+  "type": "text",
+  "messaging_product": "whatsapp"
+}

--- a/src/test/resources/json/whatsapp/send-message-recipient-only.json
+++ b/src/test/resources/json/whatsapp/send-message-recipient-only.json
@@ -1,0 +1,8 @@
+{
+  "recipient": "US.13491208655302741918",
+  "text": {
+    "body": "hello via bsuid"
+  },
+  "type": "text",
+  "messaging_product": "whatsapp"
+}

--- a/src/test/resources/json/whatsapp/send-message-to-and-recipient.json
+++ b/src/test/resources/json/whatsapp/send-message-to-and-recipient.json
@@ -1,0 +1,9 @@
+{
+  "to": "+16505551234",
+  "recipient": "US.13491208655302741918",
+  "text": {
+    "body": "hello with fallback"
+  },
+  "type": "text",
+  "messaging_product": "whatsapp"
+}


### PR DESCRIPTION
## Summary
- add WhatsApp `recipient` support to `SendMessage` for BSUID and parent BSUID targeting while preserving existing `to` behavior
- add `SendMessage` factory methods for phone-only, recipient-only, and combined phone-plus-recipient requests
- extend `SuccessfulResponse` and tests with resource-based JSON fixtures for BSUID and phone-precedence send responses

## Verification
- mvn -Dtest=SendMessageTest,SendMessageJsonTest,SendMessage1268Test test
- mvn test

## Related
- #1645