### PR TITLE
feat(message): map generic template attachments

### DIFF
--- a/src/main/lombok/com/restfb/types/Message.java
+++ b/src/main/lombok/com/restfb/types/Message.java
@@ -243,6 +243,16 @@ public class Message extends FacebookType implements HasCreatedTime, HasFrom, Ha
     private VideoData videoData;
 
     /**
+     * When the attachment is a generic template, Facebook returns title, subtitle, media URL and CTA metadata.
+     *
+     * @return The attachment's generic template data.
+     */
+    @Getter
+    @Setter
+    @Facebook("generic_template")
+    private GenericTemplate genericTemplate;
+
+    /**
      * returns if the attachment is an image
      * 
      * @return true if the attachment is an image, false otherwise
@@ -261,6 +271,15 @@ public class Message extends FacebookType implements HasCreatedTime, HasFrom, Ha
     }
 
     /**
+     * returns if the attachment is a generic template
+     *
+     * @return true if the attachment is a generic template, false otherwise
+     */
+    public boolean isGenericTemplate() {
+      return null != genericTemplate;
+    }
+
+    /**
      * returns if the attachment is a placeholder for the real attachment, that is not accessible via API due to privacy
      * rules in Europe
      *
@@ -272,6 +291,57 @@ public class Message extends FacebookType implements HasCreatedTime, HasFrom, Ha
       return "1234".equals(getId());
     }
 
+  }
+
+  /**
+   * Additional attachment information, only present when the attachment is a generic template.
+   */
+  public static class GenericTemplate extends AbstractFacebookType {
+
+    private static final long serialVersionUID = 1L;
+
+    @Getter
+    @Setter
+    @Facebook
+    private String title;
+
+    @Getter
+    @Setter
+    @Facebook
+    private String subtitle;
+
+    @Getter
+    @Setter
+    @Facebook("media_url")
+    private String mediaUrl;
+
+    @Getter
+    @Setter
+    @Facebook
+    private GenericTemplateCallToAction cta;
+  }
+
+  /**
+   * Call-to-action metadata included in a generic template attachment.
+   */
+  public static class GenericTemplateCallToAction extends AbstractFacebookType {
+
+    private static final long serialVersionUID = 1L;
+
+    @Getter
+    @Setter
+    @Facebook
+    private String title;
+
+    @Getter
+    @Setter
+    @Facebook
+    private String type;
+
+    @Getter
+    @Setter
+    @Facebook
+    private String url;
   }
 
   /**

--- a/src/test/java/com/restfb/types/MessageTest.java
+++ b/src/test/java/com/restfb/types/MessageTest.java
@@ -96,6 +96,29 @@ class MessageTest extends AbstractJsonMapperTests {
   }
 
   @Test
+  void messageWithGenericTemplateAttachment() {
+    Message exampleMessage =
+        createJsonMapper().toJavaObject(jsonFromClasspath("v10_0/message-with-generic-template"), Message.class);
+
+    assertThat(exampleMessage).isNotNull();
+    assertThat(exampleMessage.getAttachments()).hasSize(1);
+
+    Message.Attachment attachment = exampleMessage.getAttachments().get(0);
+    assertThat(attachment.isGenericTemplate()).isTrue();
+    assertThat(attachment.getGenericTemplate()).isNotNull();
+    assertThat(attachment.getGenericTemplate().getTitle()).isEqualTo("Featured product");
+    assertThat(attachment.getGenericTemplate().getSubtitle()).isEqualTo("Limited edition release");
+    assertThat(attachment.getGenericTemplate().getMediaUrl()).isEqualTo("https://example.org/item.png");
+    assertThat(attachment.getGenericTemplate().getCta()).isNotNull();
+    assertThat(attachment.getGenericTemplate().getCta().getTitle()).isEqualTo("View item");
+    assertThat(attachment.getGenericTemplate().getCta().getType()).isEqualTo("web_url");
+    assertThat(attachment.getGenericTemplate().getCta().getUrl()).isEqualTo("https://example.org/item");
+    assertThat(attachment.getImageData()).isNull();
+    assertThat(attachment.getVideoData()).isNull();
+    assertThat(attachment.getFileUrl()).isNull();
+  }
+
+  @Test
   void v10_instagram() {
     Message exampleMessage = createJsonMapper().toJavaObject(jsonFromClasspath("v10_0/instagram-message"), Message.class);
     assertThat(exampleMessage).isNotNull();

--- a/src/test/java/com/restfb/types/MessageTest.java
+++ b/src/test/java/com/restfb/types/MessageTest.java
@@ -116,6 +116,12 @@ class MessageTest extends AbstractJsonMapperTests {
     assertThat(attachment.getImageData()).isNull();
     assertThat(attachment.getVideoData()).isNull();
     assertThat(attachment.getFileUrl()).isNull();
+
+    List<Message> messageList =
+        createJsonMapper().toJavaList(jsonFromClasspath("v2_5/messages-with-attachments"), Message.class);
+    Message.Attachment nonGenericAttachment = messageList.get(0).getAttachments().get(0);
+    assertThat(nonGenericAttachment.isGenericTemplate()).isFalse();
+    assertThat(nonGenericAttachment.getGenericTemplate()).isNull();
   }
 
   @Test

--- a/src/test/resources/json/v10_0/message-with-generic-template.json
+++ b/src/test/resources/json/v10_0/message-with-generic-template.json
@@ -1,0 +1,20 @@
+{
+  "id": "<MESSAGE_ID>",
+  "attachments": {
+    "data": [
+      {
+        "id": "<ATTACHMENT_ID>",
+        "generic_template": {
+          "title": "Featured product",
+          "subtitle": "Limited edition release",
+          "media_url": "https://example.org/item.png",
+          "cta": {
+            "title": "View item",
+            "type": "web_url",
+            "url": "https://example.org/item"
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for Facebook generic template attachments in messages, exposing title, subtitle, media URL and call-to-action (title, type, URL) fields and a predicate to identify generic-template attachments.

* **Tests**
  * Added unit tests validating deserialization of generic template attachments and ensuring backward compatibility with older attachment formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->