### PR TITLE
fix(instagram): map IG container copyright check status

### DIFF
--- a/src/test/java/com/restfb/types/instagram/IgContainerTest.java
+++ b/src/test/java/com/restfb/types/instagram/IgContainerTest.java
@@ -21,42 +21,26 @@
  */
 package com.restfb.types.instagram;
 
-import com.restfb.Facebook;
-import com.restfb.types.AbstractFacebookType;
-import com.restfb.types.FacebookType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import lombok.Getter;
-import lombok.Setter;
+import org.junit.jupiter.api.Test;
 
-/**
- * This class represents an Instagram container object.
- * It contains information about the status and status code of an Instagram object.
- */
-@Setter
-@Getter
-public class IgContainer extends FacebookType {
+import com.restfb.AbstractJsonMapperTests;
 
-    private static final long serialVersionUID = 1L;
+class IgContainerTest extends AbstractJsonMapperTests {
 
-    @Facebook
-    private String status;
+  @Test
+  void checkJson() {
+    IgContainer igContainer = createJsonMapper().toJavaObject(jsonFromClasspath("instagram/container"), IgContainer.class);
 
-    @Facebook("status_code")
-    private String statusCode;
-
-    @Facebook("copyright_check_status")
-    private CopyrightCheckStatus copyrightCheckStatus;
-
-    @Setter
-    @Getter
-    public static class CopyrightCheckStatus extends AbstractFacebookType {
-
-        private static final long serialVersionUID = 1L;
-
-        @Facebook
-        private String status;
-
-        @Facebook("matches_found")
-        private Boolean matchesFound;
-    }
+    assertNotNull(igContainer);
+    assertEquals("17889615691921648", igContainer.getId());
+    assertEquals("FINISHED", igContainer.getStatusCode());
+    assertEquals("completed", igContainer.getStatus());
+    assertNotNull(igContainer.getCopyrightCheckStatus());
+    assertEquals("completed", igContainer.getCopyrightCheckStatus().getStatus());
+    assertTrue(igContainer.getCopyrightCheckStatus().getMatchesFound());
+  }
 }

--- a/src/test/java/com/restfb/types/instagram/IgContainerTest.java
+++ b/src/test/java/com/restfb/types/instagram/IgContainerTest.java
@@ -23,6 +23,7 @@ package com.restfb.types.instagram;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -42,5 +43,17 @@ class IgContainerTest extends AbstractJsonMapperTests {
     assertNotNull(igContainer.getCopyrightCheckStatus());
     assertEquals("completed", igContainer.getCopyrightCheckStatus().getStatus());
     assertTrue(igContainer.getCopyrightCheckStatus().getMatchesFound());
+  }
+
+  @Test
+  void checkJson_missingCopyrightCheckStatus() {
+    IgContainer igContainer = createJsonMapper().toJavaObject(jsonFromClasspath("instagram/container_no_copyright"),
+      IgContainer.class);
+
+    assertNotNull(igContainer);
+    assertEquals("17889615691921648", igContainer.getId());
+    assertEquals("in_progress", igContainer.getStatus());
+    assertEquals("IN_PROGRESS", igContainer.getStatusCode());
+    assertNull(igContainer.getCopyrightCheckStatus());
   }
 }

--- a/src/test/resources/json/instagram/container.json
+++ b/src/test/resources/json/instagram/container.json
@@ -1,0 +1,9 @@
+{
+  "id": "17889615691921648",
+  "status": "completed",
+  "status_code": "FINISHED",
+  "copyright_check_status": {
+    "matches_found": true,
+    "status": "completed"
+  }
+}

--- a/src/test/resources/json/instagram/container_no_copyright.json
+++ b/src/test/resources/json/instagram/container_no_copyright.json
@@ -1,0 +1,5 @@
+{
+  "id": "17889615691921648",
+  "status": "in_progress",
+  "status_code": "IN_PROGRESS"
+}


### PR DESCRIPTION
## Summary
- Add `copyright_check_status` mapping to `IgContainer`
- Cover IG container JSON mapping with a unit test and fixture

## Verification
- `mvn -Dtest=IgContainerTest test`
- `mvn test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Instagram containers now include copyright check status, exposing check completion state and whether matches were found.

* **Tests**
  * Added tests covering JSON deserialization for containers with and without copyright check status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->