### PR TITLE
feat(instagram): add collaboration invite type

### DIFF
--- a/src/main/lombok/com/restfb/types/instagram/IgCollaborativeInvite.java
+++ b/src/main/lombok/com/restfb/types/instagram/IgCollaborativeInvite.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2010-2026 Mark Allen, Norbert Bartels.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.restfb.types.instagram;
+
+import com.restfb.Facebook;
+import com.restfb.types.AbstractFacebookType;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Represents an Instagram collaboration invite.
+ *
+ * @see <a href="https://developers.facebook.com/docs/instagram-platform/instagram-api-with-facebook-login/collaboration#fetch-collaboration-invites">Fetch Collaboration Invites</a>
+ */
+public class IgCollaborativeInvite extends AbstractFacebookType {
+
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * The ID of the Instagram Media object tagged for collaboration.
+   */
+  @Getter
+  @Setter
+  @Facebook("media_id")
+  private String mediaId;
+
+  /**
+   * Instagram username of the media owner who invited the app user's Instagram account for collaboration.
+   */
+  @Getter
+  @Setter
+  @Facebook("media_owner_username")
+  private String mediaOwnerUsername;
+
+  /**
+   * Caption of the tagged Instagram Media.
+   */
+  @Getter
+  @Setter
+  @Facebook
+  private String caption;
+
+  /**
+   * Viewable CDN URL of the tagged Instagram Media.
+   */
+  @Getter
+  @Setter
+  @Facebook("media_url")
+  private String mediaUrl;
+}

--- a/src/main/lombok/com/restfb/types/instagram/IgMedia.java
+++ b/src/main/lombok/com/restfb/types/instagram/IgMedia.java
@@ -57,6 +57,8 @@ public class IgMedia extends IgMediaChild {
   /**
    * Caption. Excludes album children. The @ symbol is excluded, unless the app user can perform admin-equivalent tasks
    * on the Facebook Page connected to the Instagram account used to create the caption.
+   * <p>
+   * Available for the {@code collaborative_media} connection.
    */
   @Getter
   @Setter
@@ -67,6 +69,8 @@ public class IgMedia extends IgMediaChild {
    * Count of comments on the media.
    * <p>
    * Excludes comments on album child media and the media's caption. Includes replies on comments.
+   * <p>
+   * Available for the {@code collaborative_media} connection.
    */
   @Getter
   @Setter
@@ -101,6 +105,8 @@ public class IgMedia extends IgMediaChild {
    * <li><strong>v10.0 and older calls</strong>: value will be 0 if the media owner has hidden like counts it.</li>
    * <li><strong>v11.0+ calls</strong>: field will be omitted if media owner has hidden like counts on it.</li>
    * </ul>
+   * <p>
+   * Available for the {@code collaborative_media} connection.
    */
   @Getter
   @Setter
@@ -123,6 +129,8 @@ public class IgMedia extends IgMediaChild {
    * <p>
    * Available for FEED and REELS media. Not accessible through Hashtag API endpoints. Only available for the Instagram
    * API with Facebook Login.
+   * <p>
+   * Available for the {@code collaborative_media} connection.
    */
   @Getter
   @Setter
@@ -134,6 +142,8 @@ public class IgMedia extends IgMediaChild {
    * <p>
    * Available for FEED and REELS media. Only accessible to the media owner or an accepted collaborator. Not accessible
    * through Business Discovery, tagged media, mentioned media, or Hashtag API endpoints.
+   * <p>
+   * Available for the {@code collaborative_media} connection.
    */
   @Getter
   @Setter
@@ -145,6 +155,8 @@ public class IgMedia extends IgMediaChild {
    * <p>
    * Available for FEED and REELS media. Not accessible through Business Discovery or Hashtag API endpoints. Only
    * available for the Instagram API with Facebook Login.
+   * <p>
+   * Available for the {@code collaborative_media} connection.
    */
   @Getter
   @Setter
@@ -156,6 +168,8 @@ public class IgMedia extends IgMediaChild {
    * <p>
    * Includes comments on related boosted or promoted media. Not accessible through Hashtag API endpoints. Only available
    * for the Instagram API with Facebook Login.
+   * <p>
+   * Available for the {@code collaborative_media} connection.
    */
   @Getter
   @Setter
@@ -167,6 +181,8 @@ public class IgMedia extends IgMediaChild {
    * <p>
    * Includes likes on related boosted or promoted media. Not accessible through Hashtag API endpoints. Only available for
    * the Instagram API with Facebook Login.
+   * <p>
+   * Available for the {@code collaborative_media} connection.
    */
   @Getter
   @Setter
@@ -178,6 +194,8 @@ public class IgMedia extends IgMediaChild {
    * <p>
    * Includes views through boosted or promoted media and replays. Only available for video media. Not accessible through
    * Business Discovery or Hashtag API endpoints; use {@code view_count} for Business Discovery.
+   * <p>
+   * Available for the {@code collaborative_media} connection.
    */
   @Getter
   @Setter
@@ -186,6 +204,8 @@ public class IgMedia extends IgMediaChild {
 
   /**
    * Media thumbnail URL. Only available on VIDEO media.
+   * <p>
+   * Available for the {@code collaborative_media} connection.
    */
   @Getter
   @Setter

--- a/src/main/lombok/com/restfb/types/instagram/IgMediaChild.java
+++ b/src/main/lombok/com/restfb/types/instagram/IgMediaChild.java
@@ -40,6 +40,8 @@ public class IgMediaChild extends FacebookType {
 
   /**
    * Media type. Can be CAROUSEL_ALBUM, IMAGE, or VIDEO.
+   * <p>
+   * Available for the {@code collaborative_media} connection.
    */
   @Getter
   @Setter
@@ -49,6 +51,8 @@ public class IgMediaChild extends FacebookType {
   /**
    * Media URL. Will be omitted from responses if the media contains copyrighted material, or has been flagged for a
    * copyright violation.
+   * <p>
+   * Available for the {@code collaborative_media} connection.
    */
   @Getter
   @Setter
@@ -57,6 +61,8 @@ public class IgMediaChild extends FacebookType {
 
   /**
    * Surface where the media is published. Can be AD, FEED, or STORY.
+   * <p>
+   * Available for the {@code collaborative_media} connection.
    */
   @Getter
   @Setter
@@ -77,6 +83,8 @@ public class IgMediaChild extends FacebookType {
 
   /**
    * Permanent URL to the media.
+   * <p>
+   * Available for the {@code collaborative_media} connection.
    */
   @Getter
   @Setter
@@ -93,6 +101,8 @@ public class IgMediaChild extends FacebookType {
 
   /**
    * Media thumbnail URL. Only available on VIDEO media.
+   * <p>
+   * Available for the {@code collaborative_media} connection.
    */
   @Getter
   @Setter
@@ -101,6 +111,8 @@ public class IgMediaChild extends FacebookType {
 
   /**
    * ISO 8601 formatted creation date in UTC (default is UTC ±00:00)
+   * <p>
+   * Available for the {@code collaborative_media} connection.
    */
   @Getter
   @Setter
@@ -109,6 +121,8 @@ public class IgMediaChild extends FacebookType {
 
   /**
    * Username of user who created the media.
+   * <p>
+   * Available for the {@code collaborative_media} connection.
    */
   @Getter
   @Setter


### PR DESCRIPTION
## Summary
- Add `IgCollaborativeInvite` for Instagram collaboration invite responses from `/<IG_USER_ID>/collaboration_invites`.
- Mark existing `IgMedia` and `IgMediaChild` fields that are documented for the `collaborative_media` connection.

## Verification
- `mvn -DskipTests compile`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Instagram collaborative invites, including media details, owner information, and captions.

* **Documentation**
  * Updated documentation to reflect field availability for collaborative media connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->