### PR TITLE
#1672: remove usages of graph-video.facebook.com

### DIFF
--- a/src/main/java/com/restfb/DefaultFacebookClient.java
+++ b/src/main/java/com/restfb/DefaultFacebookClient.java
@@ -1164,8 +1164,6 @@ public class DefaultFacebookClient extends BaseFacebookClient implements Faceboo
     String baseUrl = getFacebookGraphEndpointUrl();
     if (hasAttachment && hasReel) {
       baseUrl = getFacebookReelsUploadEndpointUrl();
-    } else if (hasAttachment && (apiCall.endsWith("/videos") || apiCall.endsWith("/advideos"))) {
-      baseUrl = getFacebookGraphVideoEndpointUrl();
     } else if (apiCall.endsWith("logout.php")) {
       baseUrl = getFacebookEndpointUrls().getFacebookEndpoint();
     }
@@ -1182,20 +1180,6 @@ public class DefaultFacebookClient extends BaseFacebookClient implements Faceboo
       return getFacebookEndpointUrls().getGraphEndpoint() + '/' + apiVersion.getUrlElement();
     } else {
       return getFacebookEndpointUrls().getGraphEndpoint();
-    }
-  }
-
-  /**
-   * Returns the base endpoint URL for the Graph APIs video upload functionality.
-   * 
-   * @return The base endpoint URL for the Graph APIs video upload functionality.
-   * @since 1.6.5
-   */
-  protected String getFacebookGraphVideoEndpointUrl() {
-    if (apiVersion.isUrlElementRequired()) {
-      return getFacebookEndpointUrls().getGraphVideoEndpoint() + '/' + apiVersion.getUrlElement();
-    } else {
-      return getFacebookEndpointUrls().getGraphVideoEndpoint();
     }
   }
 

--- a/src/main/java/com/restfb/FacebookEndpoints.java
+++ b/src/main/java/com/restfb/FacebookEndpoints.java
@@ -57,15 +57,6 @@ public interface FacebookEndpoints {
   }
 
   /**
-   * returns the Facebook Graph API Video endpoint URL
-   * 
-   * @return the Facebook Graph API Video endpoint URL
-   */
-  default String getGraphVideoEndpoint() {
-    return Endpoint.GRAPH_VIDEO.getUrl();
-  }
-
-  /**
    * returns the Facebook Reel Upload endpoint URL
    *
    * @return the Facebook Reel Upload endpoint URL
@@ -106,12 +97,13 @@ public interface FacebookEndpoints {
     GRAPH("https://graph.facebook.com"),
 
     /**
-     * Video Upload API endpoint URL.
+     * Legacy Video Upload API endpoint URL.
      */
+    @Deprecated
     GRAPH_VIDEO("https://graph-video.facebook.com"),
 
     /**
-     * Reels Upload endpont URL.
+     * Reels Upload endpoint URL.
      */
     RUPLOAD("https://rupload.facebook.com/video-upload"),
 


### PR DESCRIPTION
#1672: Remove video endpoint specific handling for video upload URLs since it is deprecated according to [Meta Docs](https://developers.facebook.com/docs/video-api/overview/) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Deprecation**
  * The legacy Graph API video upload endpoint is now marked deprecated and should not be used in new implementations.

* **Breaking Changes**
  * Video upload routing via Graph API `/videos` and `/advideos` paths has been removed. Applications relying on this functionality must migrate to alternative solutions. Reels upload capability remains available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/restfb/restfb/pull/1673?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->