### PR TITLE
feat(instagram): add audio response types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # RestFB Changelog
 
+## 2026.7.0 (unreleased)
+
+* Add Instagram Audio API response types
+
 ## 2026.6.0 (May 8, 2026)
 
 * Issue #1667: map `IgContainer` copyright check status

--- a/src/main/lombok/com/restfb/types/instagram/IgAudio.java
+++ b/src/main/lombok/com/restfb/types/instagram/IgAudio.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2010-2026 Mark Allen, Norbert Bartels.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.restfb.types.instagram;
+
+import com.restfb.Facebook;
+import com.restfb.types.AbstractFacebookType;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Represents an Instagram audio asset returned by the
+ * <a href="https://developers.facebook.com/docs/instagram-platform/content-publishing/audio-api/">Instagram Audio
+ * API</a>.
+ */
+@Setter
+public class IgAudio extends AbstractFacebookType {
+
+  private static final long serialVersionUID = 1L;
+
+  @Getter
+  @Facebook("audio_id")
+  private String audioId;
+
+  // Meta's Audio API documentation uses "uri" for search responses and "url" for metadata responses.
+  @Facebook("cover_artwork_thumbnail_url")
+  private String coverArtworkThumbnailUrl;
+
+  @Facebook("cover_artwork_thumbnail_uri")
+  private String coverArtworkThumbnailUri;
+
+  @Getter
+  @Facebook("display_artist")
+  private String displayArtist;
+
+  @Getter
+  @Facebook("duration_in_ms")
+  private Integer durationInMs;
+
+  @Getter
+  @Facebook("audio_type")
+  private String audioType;
+
+  @Getter
+  @Facebook
+  private String title;
+
+  @Getter
+  @Facebook("download_url")
+  private String downloadUrl;
+
+  @Getter
+  @Facebook("ig_username")
+  private String igUsername;
+
+  @Getter
+  @Facebook("profile_picture_url")
+  private String profilePictureUrl;
+
+  public String getCoverArtworkThumbnailUrl() {
+    return coverArtworkThumbnailUrl != null ? coverArtworkThumbnailUrl : coverArtworkThumbnailUri;
+  }
+
+  public String getCoverArtworkThumbnailUri() {
+    return coverArtworkThumbnailUri != null ? coverArtworkThumbnailUri : coverArtworkThumbnailUrl;
+  }
+}

--- a/src/main/lombok/com/restfb/types/instagram/IgAudioResponse.java
+++ b/src/main/lombok/com/restfb/types/instagram/IgAudioResponse.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2010-2026 Mark Allen, Norbert Bartels.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.restfb.types.instagram;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.restfb.Facebook;
+import com.restfb.types.AbstractFacebookType;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Response returned by the Instagram Audio API search endpoint.
+ */
+@Getter
+@Setter
+public class IgAudioResponse extends AbstractFacebookType {
+
+  private static final long serialVersionUID = 1L;
+
+  @Facebook
+  private List<IgAudio> audio = new ArrayList<>();
+}

--- a/src/test/java/com/restfb/types/instagram/IgAudioTest.java
+++ b/src/test/java/com/restfb/types/instagram/IgAudioTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2010-2026 Mark Allen, Norbert Bartels.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.restfb.types.instagram;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+import com.restfb.AbstractJsonMapperTests;
+
+class IgAudioTest extends AbstractJsonMapperTests {
+
+  @Test
+  void checkSearchResponseJson() {
+    IgAudioResponse response = createJsonMapper().toJavaObject(jsonFromClasspath("instagram/audio-response"),
+      IgAudioResponse.class);
+
+    assertNotNull(response);
+    assertEquals(2, response.getAudio().size());
+
+    IgAudio musicAudio = response.getAudio().get(0);
+    assertEquals("587784541076604", musicAudio.getAudioId());
+    assertEquals("https://scontent.example/cover.jpg", musicAudio.getCoverArtworkThumbnailUrl());
+    assertEquals("https://scontent.example/cover.jpg", musicAudio.getCoverArtworkThumbnailUri());
+    assertEquals("Shuba", musicAudio.getDisplayArtist());
+    assertEquals(153760, musicAudio.getDurationInMs());
+    assertEquals("music", musicAudio.getAudioType());
+    assertEquals("Birthday Wish", musicAudio.getTitle());
+    assertEquals("https://scontent.example/audio.mp3", musicAudio.getDownloadUrl());
+    assertNull(musicAudio.getIgUsername());
+    assertNull(musicAudio.getProfilePictureUrl());
+
+    IgAudio originalSoundAudio = response.getAudio().get(1);
+    assertEquals("1234567890", originalSoundAudio.getAudioId());
+    assertEquals("original_sound", originalSoundAudio.getAudioType());
+    assertEquals("restfb", originalSoundAudio.getIgUsername());
+    assertEquals("https://scontent.example/profile.jpg", originalSoundAudio.getProfilePictureUrl());
+    assertNull(originalSoundAudio.getDisplayArtist());
+    assertNull(originalSoundAudio.getCoverArtworkThumbnailUrl());
+  }
+
+  @Test
+  void checkMetadataJson() {
+    IgAudio igAudio = createJsonMapper().toJavaObject(jsonFromClasspath("instagram/audio-metadata"), IgAudio.class);
+
+    assertNotNull(igAudio);
+    assertEquals("587784541076604", igAudio.getAudioId());
+    assertEquals("https://scontent.example/cover-metadata.jpg", igAudio.getCoverArtworkThumbnailUrl());
+    assertEquals("https://scontent.example/cover-metadata.jpg", igAudio.getCoverArtworkThumbnailUri());
+    assertEquals("Shuba", igAudio.getDisplayArtist());
+    assertEquals(153760, igAudio.getDurationInMs());
+    assertEquals("music", igAudio.getAudioType());
+    assertEquals("Birthday Wish", igAudio.getTitle());
+    assertEquals("https://scontent.example/audio-metadata.mp3", igAudio.getDownloadUrl());
+  }
+}

--- a/src/test/java/com/restfb/types/instagram/IgAudioTest.java
+++ b/src/test/java/com/restfb/types/instagram/IgAudioTest.java
@@ -24,10 +24,12 @@ package com.restfb.types.instagram;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
 import com.restfb.AbstractJsonMapperTests;
+import com.restfb.exception.FacebookJsonMappingException;
 
 class IgAudioTest extends AbstractJsonMapperTests {
 
@@ -73,5 +75,43 @@ class IgAudioTest extends AbstractJsonMapperTests {
     assertEquals("music", igAudio.getAudioType());
     assertEquals("Birthday Wish", igAudio.getTitle());
     assertEquals("https://scontent.example/audio-metadata.mp3", igAudio.getDownloadUrl());
+  }
+
+  @Test
+  void checkEmptyJsonThrows() {
+    assertThrows(FacebookJsonMappingException.class,
+      () -> createJsonMapper().toJavaObject("", IgAudioResponse.class));
+    assertThrows(FacebookJsonMappingException.class, () -> createJsonMapper().toJavaObject("", IgAudio.class));
+  }
+
+  @Test
+  void checkNullJsonThrows() {
+    assertThrows(FacebookJsonMappingException.class,
+      () -> createJsonMapper().toJavaObject(null, IgAudioResponse.class));
+    assertThrows(FacebookJsonMappingException.class, () -> createJsonMapper().toJavaObject(null, IgAudio.class));
+  }
+
+  @Test
+  void checkMalformedJsonHandling() {
+    assertThrows(FacebookJsonMappingException.class,
+      () -> createJsonMapper().toJavaObject("{\"audio\": [", IgAudioResponse.class));
+    assertThrows(FacebookJsonMappingException.class,
+      () -> createJsonMapper().toJavaObject("{\"audio_id\":", IgAudio.class));
+  }
+
+  @Test
+  void checkMissingFieldsDefaults() {
+    IgAudioResponse response = createJsonMapper().toJavaObject("{}", IgAudioResponse.class);
+
+    assertNotNull(response);
+    assertNotNull(response.getAudio());
+    assertEquals(0, response.getAudio().size());
+
+    IgAudio igAudio = createJsonMapper().toJavaObject("{}", IgAudio.class);
+
+    assertNotNull(igAudio);
+    assertNull(igAudio.getAudioId());
+    assertNull(igAudio.getTitle());
+    assertNull(igAudio.getDurationInMs());
   }
 }

--- a/src/test/resources/json/instagram/audio-metadata.json
+++ b/src/test/resources/json/instagram/audio-metadata.json
@@ -1,0 +1,9 @@
+{
+  "audio_id": "587784541076604",
+  "cover_artwork_thumbnail_url": "https://scontent.example/cover-metadata.jpg",
+  "display_artist": "Shuba",
+  "duration_in_ms": 153760,
+  "audio_type": "music",
+  "title": "Birthday Wish",
+  "download_url": "https://scontent.example/audio-metadata.mp3"
+}

--- a/src/test/resources/json/instagram/audio-response.json
+++ b/src/test/resources/json/instagram/audio-response.json
@@ -1,0 +1,22 @@
+{
+  "audio": [
+    {
+      "audio_id": "587784541076604",
+      "cover_artwork_thumbnail_uri": "https://scontent.example/cover.jpg",
+      "display_artist": "Shuba",
+      "duration_in_ms": 153760,
+      "audio_type": "music",
+      "title": "Birthday Wish",
+      "download_url": "https://scontent.example/audio.mp3"
+    },
+    {
+      "audio_id": "1234567890",
+      "duration_in_ms": 104000,
+      "audio_type": "original_sound",
+      "title": "Original Audio",
+      "download_url": "https://scontent.example/original.mp3",
+      "ig_username": "restfb",
+      "profile_picture_url": "https://scontent.example/profile.jpg"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Instagram Audio API DTOs for audio assets and search responses
- map both documented cover artwork field variants: cover_artwork_thumbnail_uri and cover_artwork_thumbnail_url
- add JSON mapper tests and fixtures for search and metadata responses

## Verification
- mvn -Dtest=IgAudioTest test
- mvn test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Instagram Audio API support: retrieve audio metadata (IDs, artist, duration, type, title, download URLs) and cover artwork with fallback handling.
* **Tests**
  * Added extensive parsing tests, including positive mappings, missing-field scenarios, and malformed/empty-response handling to ensure robust behavior.
* **Documentation**
  * Updated changelog with a 2026.7.0 (unreleased) entry noting Instagram Audio API response types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/restfb/restfb/pull/1674?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->