### PR TITLE
feat(messaging): convert participants to message recipients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2026.7.0 (unreleased)
 
 * Add Instagram Audio API response types
+* Add `MessagingParticipant` conversion to Send API message recipients
 
 ## 2026.6.0 (May 8, 2026)
 

--- a/src/test/java/com/restfb/types/webhook/messaging/MessagingParticipantTest.java
+++ b/src/test/java/com/restfb/types/webhook/messaging/MessagingParticipantTest.java
@@ -23,6 +23,7 @@ package com.restfb.types.webhook.messaging;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 
@@ -59,5 +60,13 @@ class MessagingParticipantTest {
     UserRefMessageRecipient recipient =
         assertInstanceOf(UserRefMessageRecipient.class, participant.toMessageRecipient());
     assertEquals("UNIQUE_USER_REF", recipient.getUserRef());
+  }
+
+  @Test
+  void toMessageRecipientUsesNullId() {
+    MessagingParticipant participant = new MessagingParticipant();
+
+    IdMessageRecipient recipient = assertInstanceOf(IdMessageRecipient.class, participant.toMessageRecipient());
+    assertNull(recipient.getId());
   }
 }

--- a/src/test/java/com/restfb/types/webhook/messaging/MessagingParticipantTest.java
+++ b/src/test/java/com/restfb/types/webhook/messaging/MessagingParticipantTest.java
@@ -21,42 +21,43 @@
  */
 package com.restfb.types.webhook.messaging;
 
-import com.restfb.Facebook;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import org.junit.jupiter.api.Test;
+
 import com.restfb.types.send.IdMessageRecipient;
-import com.restfb.types.send.MessageRecipient;
 import com.restfb.types.send.UserRefMessageRecipient;
 
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+class MessagingParticipantTest {
 
-@ToString
-public class MessagingParticipant {
+  @Test
+  void toMessageRecipientUsesId() {
+    MessagingParticipant participant = new MessagingParticipant();
+    participant.setId("12345");
 
-  @Getter
-  @Setter
-  @Facebook
-  private String id;
-
-  /**
-   * The user_ref of the user that triggered the webhook event.
-   *
-   * This is only available for webhook event from the chat plugin.
-   */
-  @Getter
-  @Setter
-  @Facebook("user_ref")
-  private String userRef;
-
-  public boolean isUserRef() {
-    return userRef != null;
+    IdMessageRecipient recipient = assertInstanceOf(IdMessageRecipient.class, participant.toMessageRecipient());
+    assertEquals("12345", recipient.getId());
   }
 
-  public MessageRecipient toMessageRecipient() {
-    if (isUserRef()) {
-      return new UserRefMessageRecipient(userRef);
-    }
+  @Test
+  void toMessageRecipientUsesUserRef() {
+    MessagingParticipant participant = new MessagingParticipant();
+    participant.setUserRef("UNIQUE_USER_REF");
 
-    return new IdMessageRecipient(id);
+    UserRefMessageRecipient recipient =
+        assertInstanceOf(UserRefMessageRecipient.class, participant.toMessageRecipient());
+    assertEquals("UNIQUE_USER_REF", recipient.getUserRef());
+  }
+
+  @Test
+  void toMessageRecipientPrefersUserRef() {
+    MessagingParticipant participant = new MessagingParticipant();
+    participant.setId("12345");
+    participant.setUserRef("UNIQUE_USER_REF");
+
+    UserRefMessageRecipient recipient =
+        assertInstanceOf(UserRefMessageRecipient.class, participant.toMessageRecipient());
+    assertEquals("UNIQUE_USER_REF", recipient.getUserRef());
   }
 }


### PR DESCRIPTION
## Summary
- add MessagingParticipant#toMessageRecipient()
- return UserRefMessageRecipient for user_ref participants and IdMessageRecipient otherwise
- cover id, user_ref, and user_ref precedence with unit tests

## Verification
- mvn -Dtest=MessagingParticipantTest test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MessagingParticipant can be converted into Send API message recipients, automatically choosing between user reference and ID for messaging operations.

* **Tests**
  * Added tests covering conversion behavior: ID-only, userRef-only, both (userRef preferred), and neither (null ID) scenarios to ensure correct recipient resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/restfb/restfb/pull/1675?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->