### PR TITLE
feat(threads): add text attachment type

### DIFF
--- a/src/main/lombok/com/restfb/types/threads/TdMedia.java
+++ b/src/main/lombok/com/restfb/types/threads/TdMedia.java
@@ -195,6 +195,11 @@ public class TdMedia extends FacebookType {
   @Facebook("poll_attachment")
   private TdPollAttachment pollAttachment;
 
+  @Getter
+  @Setter
+  @Facebook("text_attachment")
+  private TdTextAttachment textAttachment;
+
   public List<Locale> getAllowlistedCountryCodesAsLocales() {
     List<Locale> locales = new ArrayList<>();
     for (String code : allowlistedCountryCodes) {

--- a/src/main/lombok/com/restfb/types/threads/TdTextAttachment.java
+++ b/src/main/lombok/com/restfb/types/threads/TdTextAttachment.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2010-2026 Mark Allen, Norbert Bartels.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.restfb.types.threads;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.restfb.Facebook;
+import com.restfb.types.AbstractFacebookType;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Text attachment for Threads posts.
+ * As defined here: https://developers.facebook.com/docs/threads/create-posts/text-attachments
+ */
+public class TdTextAttachment extends AbstractFacebookType {
+
+  private static final long serialVersionUID = 1L;
+
+  @Getter
+  @Setter
+  @Facebook
+  private String plaintext;
+
+  @Getter
+  @Setter
+  @Facebook("link_attachment_url")
+  private String linkAttachmentUrl;
+
+  @Getter
+  @Setter
+  @Facebook("text_with_styling_info")
+  private List<TextWithStylingInfo> textWithStylingInfo = new ArrayList<>();
+
+  public static class TextWithStylingInfo extends AbstractFacebookType {
+
+    private static final long serialVersionUID = 1L;
+
+    @Getter
+    @Setter
+    @Facebook
+    private Integer offset;
+
+    @Getter
+    @Setter
+    @Facebook
+    private Integer length;
+
+    @Getter
+    @Setter
+    @Facebook("styling_info")
+    private List<String> stylingInfo = new ArrayList<>();
+  }
+}

--- a/src/test/java/com/restfb/types/threads/TdMediaTest.java
+++ b/src/test/java/com/restfb/types/threads/TdMediaTest.java
@@ -64,6 +64,31 @@ class TdMediaTest extends AbstractJsonMapperTests {
   }
 
   @Test
+  void checkTextAttachment() {
+    TdMedia threadsMedia =
+        createJsonMapper().toJavaObject(jsonFromClasspath("threads/media-with-text-attachment"), TdMedia.class);
+    assertNotNull(threadsMedia);
+    assertEquals("<THREADS_MEDIA_ID>", threadsMedia.getId());
+    assertNotNull(threadsMedia.getTextAttachment());
+
+    TdTextAttachment textAttachment = threadsMedia.getTextAttachment();
+    assertEquals("Lengthy plaintext for the text attachment.", textAttachment.getPlaintext());
+    assertEquals("<LINK_URL>", textAttachment.getLinkAttachmentUrl());
+    assertEquals(2, textAttachment.getTextWithStylingInfo().size());
+
+    TdTextAttachment.TextWithStylingInfo firstStylingInfo = textAttachment.getTextWithStylingInfo().get(0);
+    assertEquals(0, firstStylingInfo.getOffset());
+    assertEquals(7, firstStylingInfo.getLength());
+    assertEquals("bold", firstStylingInfo.getStylingInfo().get(0));
+    assertEquals("italic", firstStylingInfo.getStylingInfo().get(1));
+
+    TdTextAttachment.TextWithStylingInfo secondStylingInfo = textAttachment.getTextWithStylingInfo().get(1);
+    assertEquals(7, secondStylingInfo.getOffset());
+    assertEquals(10, secondStylingInfo.getLength());
+    assertEquals("highlight", secondStylingInfo.getStylingInfo().get(0));
+  }
+
+  @Test
   void checkLocation() {
     TdMedia threadsMedia = createJsonMapper().toJavaObject(jsonFromClasspath("threads/media-with-location"), TdMedia.class);
     assertNotNull(threadsMedia);

--- a/src/test/java/com/restfb/types/threads/TdMediaTest.java
+++ b/src/test/java/com/restfb/types/threads/TdMediaTest.java
@@ -23,6 +23,8 @@ package com.restfb.types.threads;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -86,6 +88,38 @@ class TdMediaTest extends AbstractJsonMapperTests {
     assertEquals(7, secondStylingInfo.getOffset());
     assertEquals(10, secondStylingInfo.getLength());
     assertEquals("highlight", secondStylingInfo.getStylingInfo().get(0));
+  }
+
+  @Test
+  void checkMissingTextAttachment() {
+    TdMedia threadsMedia =
+        createJsonMapper().toJavaObject(jsonFromClasspath("threads/media-without-text-attachment"), TdMedia.class);
+
+    assertNotNull(threadsMedia);
+    assertNull(threadsMedia.getTextAttachment());
+  }
+
+  @Test
+  void checkTextAttachmentWithEmptyStylingInfo() {
+    TdMedia threadsMedia =
+        createJsonMapper().toJavaObject(jsonFromClasspath("threads/media-with-empty-text-styling-info"), TdMedia.class);
+
+    assertNotNull(threadsMedia);
+    TdTextAttachment textAttachment = threadsMedia.getTextAttachment();
+    assertNotNull(textAttachment);
+    assertTrue(textAttachment.getTextWithStylingInfo().isEmpty());
+  }
+
+  @Test
+  void checkTextAttachmentWithMissingOrNullFields() {
+    TdMedia threadsMedia =
+        createJsonMapper().toJavaObject(jsonFromClasspath("threads/media-with-incomplete-text-attachment"), TdMedia.class);
+
+    assertNotNull(threadsMedia);
+    TdTextAttachment textAttachment = threadsMedia.getTextAttachment();
+    assertNotNull(textAttachment);
+    assertNull(textAttachment.getPlaintext());
+    assertNull(textAttachment.getLinkAttachmentUrl());
   }
 
   @Test

--- a/src/test/resources/json/threads/media-with-empty-text-styling-info.json
+++ b/src/test/resources/json/threads/media-with-empty-text-styling-info.json
@@ -1,0 +1,8 @@
+{
+  "id": "<THREADS_MEDIA_ID>",
+  "text_attachment": {
+    "plaintext": "Lengthy plaintext for the text attachment.",
+    "link_attachment_url": "<LINK_URL>",
+    "text_with_styling_info": []
+  }
+}

--- a/src/test/resources/json/threads/media-with-incomplete-text-attachment.json
+++ b/src/test/resources/json/threads/media-with-incomplete-text-attachment.json
@@ -1,0 +1,7 @@
+{
+  "id": "<THREADS_MEDIA_ID>",
+  "text_attachment": {
+    "link_attachment_url": null,
+    "text_with_styling_info": []
+  }
+}

--- a/src/test/resources/json/threads/media-with-text-attachment.json
+++ b/src/test/resources/json/threads/media-with-text-attachment.json
@@ -1,0 +1,19 @@
+{
+  "id": "<THREADS_MEDIA_ID>",
+  "text_attachment": {
+    "plaintext": "Lengthy plaintext for the text attachment.",
+    "link_attachment_url": "<LINK_URL>",
+    "text_with_styling_info": [
+      {
+        "offset": 0,
+        "length": 7,
+        "styling_info": ["bold", "italic"]
+      },
+      {
+        "offset": 7,
+        "length": 10,
+        "styling_info": ["highlight"]
+      }
+    ]
+  }
+}

--- a/src/test/resources/json/threads/media-without-text-attachment.json
+++ b/src/test/resources/json/threads/media-without-text-attachment.json
@@ -1,0 +1,3 @@
+{
+  "id": "<THREADS_MEDIA_ID>"
+}


### PR DESCRIPTION
## Summary
- add TdTextAttachment for Threads text_attachment responses
- map text_attachment on TdMedia
- add a JSON fixture based on the Threads text attachment example response

## Verification
- mvn -Dtest=TdMediaTest test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for text attachments in Threads media: plaintext, link URLs, and styled text segments (e.g., bold, italic, highlight).

* **Tests**
  * Added tests covering parsing of text attachments, including styled segments, empty styling lists, missing or null fields, and absence of attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->