### PR TITLE
fix(video): use graph endpoint for uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # RestFB Changelog
 
+## 2026.8.0 (unreleased)
+
+* Issue #1672: use the Graph API endpoint for video uploads and deprecate the legacy Graph Video endpoint
+
 ## 2026.7.0 (May 24, 2026)
 
 * Add Instagram Audio API response types

--- a/src/main/java/com/restfb/DefaultFacebookClient.java
+++ b/src/main/java/com/restfb/DefaultFacebookClient.java
@@ -1164,8 +1164,6 @@ public class DefaultFacebookClient extends BaseFacebookClient implements Faceboo
     String baseUrl = getFacebookGraphEndpointUrl();
     if (hasAttachment && hasReel) {
       baseUrl = getFacebookReelsUploadEndpointUrl();
-    } else if (hasAttachment && (apiCall.endsWith("/videos") || apiCall.endsWith("/advideos"))) {
-      baseUrl = getFacebookGraphVideoEndpointUrl();
     } else if (apiCall.endsWith("logout.php")) {
       baseUrl = getFacebookEndpointUrls().getFacebookEndpoint();
     }
@@ -1190,7 +1188,10 @@ public class DefaultFacebookClient extends BaseFacebookClient implements Faceboo
    * 
    * @return The base endpoint URL for the Graph APIs video upload functionality.
    * @since 1.6.5
+   * @deprecated the Graph Video endpoint is deprecated; video uploads use the Graph API endpoint
+   *             instead.
    */
+  @Deprecated
   protected String getFacebookGraphVideoEndpointUrl() {
     if (apiVersion.isUrlElementRequired()) {
       return getFacebookEndpointUrls().getGraphVideoEndpoint() + '/' + apiVersion.getUrlElement();

--- a/src/main/java/com/restfb/FacebookEndpoints.java
+++ b/src/main/java/com/restfb/FacebookEndpoints.java
@@ -60,7 +60,10 @@ public interface FacebookEndpoints {
    * returns the Facebook Graph API Video endpoint URL
    * 
    * @return the Facebook Graph API Video endpoint URL
+   * @deprecated the Graph Video endpoint is deprecated; video uploads use the Graph API endpoint
+   *             instead.
    */
+  @Deprecated
   default String getGraphVideoEndpoint() {
     return Endpoint.GRAPH_VIDEO.getUrl();
   }
@@ -106,12 +109,13 @@ public interface FacebookEndpoints {
     GRAPH("https://graph.facebook.com"),
 
     /**
-     * Video Upload API endpoint URL.
+     * Legacy Video Upload API endpoint URL.
      */
+    @Deprecated
     GRAPH_VIDEO("https://graph-video.facebook.com"),
 
     /**
-     * Reels Upload endpont URL.
+     * Reels Upload endpoint URL.
      */
     RUPLOAD("https://rupload.facebook.com/video-upload"),
 

--- a/src/test/java/com/restfb/DefaultFacebookClientTest.java
+++ b/src/test/java/com/restfb/DefaultFacebookClientTest.java
@@ -115,13 +115,56 @@ class DefaultFacebookClientTest {
       });
   }
 
+  @Test
+  void videoUploadUsesGraphEndpoint() {
+    TestableFacebookClient client = new TestableFacebookClient();
+
+    assertThat(client.createEndpoint("me/videos", true, false))
+      .isEqualTo("https://graph.facebook.com/v18.0/me/videos");
+    assertThat(client.createEndpoint("act_123/advideos", true, false))
+      .isEqualTo("https://graph.facebook.com/v18.0/act_123/advideos");
+  }
+
+  @Test
+  void reelUploadStillUsesReelUploadEndpoint() {
+    TestableFacebookClient client = new TestableFacebookClient();
+
+    assertThat(client.createEndpoint("me/video_reels", true, true))
+      .isEqualTo("https://rupload.facebook.com/video-upload/v18.0/me/video_reels");
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void graphVideoEndpointMethodIsRetainedForCompatibility() {
+    TestableFacebookClient client = new TestableFacebookClient();
+
+    assertThat(client.graphVideoEndpoint()).isEqualTo("https://graph-video.facebook.com/v18.0");
+    assertThat(client.getFacebookEndpointUrls().getGraphVideoEndpoint()).isEqualTo("https://graph-video.facebook.com");
+  }
+
+  @Test
+  void logoutStillUsesFacebookEndpoint() {
+    TestableFacebookClient client = new TestableFacebookClient();
+
+    assertThat(client.createEndpoint("logout.php", false, false)).isEqualTo("https://www.facebook.com/logout.php");
+  }
+
   private static class TestableFacebookClient extends DefaultFacebookClient {
     TestableFacebookClient() {
-      super("token", new DefaultWebRequestor(), new DefaultJsonMapper(), Version.LATEST);
+      super("token", new DefaultWebRequestor(), new DefaultJsonMapper(), Version.VERSION_18_0);
     }
 
     void invokeMakeRequest(Requestor requestor) {
       executeRequestWithMetadata(null, null, requestor);
+    }
+
+    String createEndpoint(String apiCall, boolean hasAttachment, boolean hasReel) {
+      return createEndpointForApiCall(apiCall, hasAttachment, hasReel);
+    }
+
+    @SuppressWarnings("deprecation")
+    String graphVideoEndpoint() {
+      return getFacebookGraphVideoEndpointUrl();
     }
   }
 


### PR DESCRIPTION
Summary:
- Route binary uploads to /videos and /advideos through the regular Graph API endpoint instead of the deprecated Graph Video endpoint.
- Keep the legacy Graph Video endpoint API available and mark it deprecated for compatibility.
- Add routing tests for video uploads, reels uploads, logout, and retained deprecated endpoint access.
- Add a changelog entry for issue #1672.

This is a less aggressive alternative to #1673.

Verification:
- mvn -Dtest=DefaultFacebookClientTest test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecated**
  * Graph Video endpoint is deprecated. Video uploads now use the standard Graph API endpoint instead, providing a unified approach across the platform.
  * Legacy endpoint accessor methods are marked for deprecation and will be removed in future versions.

* **Tests**
  * Added comprehensive test coverage verifying correct endpoint selection for video uploads, reel uploads, and backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->