### PR TITLE
fix(ci): update lock threads action

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -8,7 +8,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v5
+      - uses: dessant/lock-threads@v6
         with:
           github-token: ${{ github.token }}
           issue-inactive-days: 90


### PR DESCRIPTION
## Summary
- update dessant/lock-threads from v5 to v6
- support GitHub's longer Actions installation tokens and Node 24 runtime

## Verification
- git diff --check
- YAML parsed successfully with Ruby Psych

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated thread-locking workflow to its latest version.
  * Existing inactivity settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->